### PR TITLE
Refine changelog and contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ This guidance applies to the entire repository. Add more specific rules in neste
 
 ## Changelog Policy
 - Record user-visible changes in the project changelog (or nearest equivalent) as part of each feature or fix. Use clear, action-oriented entries that describe the behavior change.
+- Keep changelog headings aligned with the Keep a Changelog format and remove empty sections before publishing releases.
+- When adding release documentation, ensure the process describes tagging, GitHub Releases, and any automation (or the lack thereof).
 
 ## Pull Request Message Format
 Every PR description should include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release cadence
+
+We aim to publish stable releases on a **monthly cadence**, with interim patch releases as needed for security or high-priority fixes. If a month passes without user-visible changes, we will still close out the cycle by tagging a maintenance release (for example, incrementing the patch version) to capture dependency or tooling updates.
+
+## Release process
+
+1. Ensure the `main` branch is green (lint, tests, and database migrations where applicable).
+2. Update the `## [Unreleased]` section below with any user-visible changes since the last release, grouping entries under `Added`, `Changed`, `Fixed`, and `Removed` as needed. Remove empty headings before publishing.
+3. Bump the version in `package.json` to the new release number, commit the change, and update the headings in this file to include the new version and date. Follow the Keep a Changelog structure by adding the new version section **above** `## [Unreleased]` and moving the previous `Unreleased` entries into it.
+4. Tag the release with an annotated tag (`git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`).
+5. Draft a GitHub Release using the pushed tag, copying the relevant changelog section into the release notes. Include a compare link from the previous tag (for example, `https://github.com/<org>/<repo>/compare/vA.B.C...vX.Y.Z`).
+6. Verify the deployment (preview and production, if applicable) and annotate any post-release follow-ups in the GitHub Release notes.
+
+> Automated changelog generation is **not** currently configured for this repository. If added in the future (for example, via Changesets or Release Drafter), link the workflow or script here and follow its output when drafting releases.
+
+## Writing changelog entries
+
+- Use past tense for completed work and imperative voice for guidance (for example, "Documented release cadence" vs. "Document release cadence").
+- Keep entries user-focused and succinct; prefer bullet points to paragraphs.
+- Example template when cutting a release:
+
+```
+## [Unreleased]
+
+## [X.Y.Z] - YYYY-MM-DD
+### Added
+- ...
+
+### Changed
+- ...
+
+### Fixed
+- ...
+
+### Removed
+- ...
+```
+
+## [Unreleased]
+
+### Added
+- Initial changelog scaffold and release process documentation.
+


### PR DESCRIPTION
## Summary
- expand release process steps to emphasize annotated tags, compare links, and Keep a Changelog flow
- add guidance for writing changelog entries with a reusable template
- update agent guidelines to keep release documentation aligned with tagging and automation expectations

## Testing
- not run (documentation-only changes)

## Additional Notes
- documentation-only update


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69336c94e49c8325a498d6eef94f5201)