### PR TITLE
Clarify contributor guidance precedence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,8 @@
 ## Scope
 This guidance applies to the entire repository. Add more specific rules in nested `AGENTS.md` files when necessary.
 
+`AGENTS.md` files are the authoritative source for contributor instructions. Consult them first; the `README.md` may not capture the most current guidance.
+
 ## Coding Standards
 - **TypeScript/React**: Prefer function components with hooks, uphold strict typing (no `any` unless unavoidable and documented), and keep components small and composable. Follow existing linting/formatting rules (see `biome.jsonc`).
 - **State Management**: Lift state to the lowest sensible owner and pass explicit props; avoid implicit globals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,4 +48,6 @@ We aim to publish stable releases on a **monthly cadence**, with interim patch r
 - Documented design system tokens, states, and shadcn/ui usage patterns.
 - Initial changelog scaffold and release process documentation.
 - Documented testing expectations for unit, integration, and accessibility coverage.
+- Documented data handling practices for secrets, PII, generated content, rate limiting, logging, and prompt safety.
+- Clarified that `AGENTS.md` files are the authoritative source for contributor guidance.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ pnpm dev
 
 Your app template should now be running on [localhost:3000](http://localhost:3000).
 
+## Data handling and safety
+
+Review [docs/data-handling.md](docs/data-handling.md) for guidance on managing secrets and environment variables, protecting PII, applying rate limits, logging safely, and adding guard rails to model prompts and generated content.
+
 ## Testing
 
 See [docs/testing.md](docs/testing.md) for expectations and commands covering unit (Vitest/React Testing Library), integration/end-to-end (Playwright), and accessibility checks, plus what must pass in CI before merging changes.

--- a/docs/data-handling.md
+++ b/docs/data-handling.md
@@ -1,0 +1,36 @@
+# Data handling and safety
+
+This guide explains how to keep secrets, personally identifiable information (PII), and AI-generated content safe across local development and deployments.
+
+## Secrets and environment variables
+- Store secrets in environment variables instead of source files. Copy `.env.example` to `.env.local` for local development and keep it out of version control.
+- Avoid exposing secrets to client-side code. Only variables prefixed with `NEXT_PUBLIC_` are bundled for the browser; keep all credentials server-only and reference them in Server Components, Route Handlers, or server actions.
+- Use your hosting platform's secret manager (for example, Vercel Environment Variables) for production. Rotate keys regularly and prune unused credentials.
+- Validate that every required secret is set at boot (for example, through startup checks) and fail fast with clear errors when values are missing.
+
+## Handling PII and sensitive data
+- Collect only the minimum PII required for the feature and document why it is needed.
+- Prefer server-side processing and storage so that PII never leaves trusted environments. Avoid persisting PII inside client-side state or local storage.
+- Redact or hash sensitive identifiers (emails, IP addresses, access tokens) before persisting or emitting them to analytics, logs, or monitoring systems.
+- Support deletion and export by keeping PII scoped and discoverable (for example, through a single data access layer or table).
+
+## Generated content governance
+- Label AI-generated content when shown to users and avoid presenting it as factual without verification.
+- Apply output filters (moderation, allowlists, or pattern checks) before persisting or displaying model responses. Block or flag content that violates acceptable-use policies.
+- Keep prompts, system instructions, and training snippets free of PII and secrets. Use template variables rather than hard-coding sensitive strings.
+
+## Rate limiting
+- Apply rate limits per authenticated user and IP to protect upstream model providers and database resources. Prefer short burst limits with sensible sustained ceilings.
+- Enforce limits in middleware or server handlers before expensive work (model calls, database writes, file uploads). Return clear 429 responses with retry guidance.
+- Use shared state (for example, Redis, KV, or the deployment platform's edge store) so limits are consistent across replicas.
+
+## Logging and monitoring
+- Log at the minimum level needed for debugging. Avoid logging raw prompts, full model responses, secrets, or PII. If logging is required, redact sensitive fields before emit.
+- Set retention periods and access controls for observability tooling. Delete logs that contain sensitive data as part of incident response.
+- Capture structured metadata (request ids, user ids, feature flags) to trace issues without exposing personal content.
+
+## Model prompt safety
+- Validate and normalize user inputs (length, encoding, content-type) before sending them to models.
+- Constrain model tools and actions to a minimal, auditable set. Reject tool calls that are not explicitly allowed.
+- Include safety rails in system prompts (context boundaries, refusal policies, and escalation paths). Avoid unbounded instructions or dynamic template injection.
+- Monitor model responses for safety categories (e.g., self-harm, violence, personal data) and block or escalate when detected.


### PR DESCRIPTION
## Summary
- emphasize that AGENTS.md files are the authoritative source for contributor instructions over the README
- record the documentation clarification in the changelog

## Testing
- not run (documentation-only changes)

## Additional Notes
- none

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69336ef4ae3883258cdc2b1f8124e453)