### PR TITLE
Deduplicate outlines in draft workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@
 - Data Persistence
   - [Neon](https://neon.tech/) for saving chat history and user data
   - Blob storage for efficient file storage
+- Story workspace
+  - Generate outlines with POV, tone, and pacing controls and save them per project
+  - Draft prose side-by-side with AI suggestions grounded in your lore entities
+  - Saved outlines stay deduplicated and sorted by newest first in the draft workspace
 - [Auth.js](https://authjs.dev)
   - Simple and secure authentication
 

--- a/app/(chat)/projects/[id]/drafts/actions.ts
+++ b/app/(chat)/projects/[id]/drafts/actions.ts
@@ -1,0 +1,207 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { generateText } from "ai";
+import { z } from "zod";
+import { auth } from "@/app/(auth)/auth";
+import { myProvider } from "@/lib/ai/providers";
+import {
+  getAttributesForProject,
+  getEntitiesForProject,
+  getOutlineById,
+  getProjectByIdWithAccess,
+  getRelationshipsForProject,
+  createOutline,
+} from "@/lib/db/queries";
+import type { Outline } from "@/lib/db/schema";
+import { ChatSDKError } from "@/lib/errors";
+import {
+  buildLoreContext,
+  extractBeatsFromText,
+  outlineToPrompt,
+} from "@/lib/story/lore";
+
+const outlineSchema = z.object({
+  projectId: z.string().uuid(),
+  title: z.string().min(3, "Add a title to keep outlines organized."),
+  idea: z
+    .string()
+    .min(12, "Describe the scene or chapter in at least 12 characters."),
+  pov: z.string().min(3, "Select a point of view."),
+  tone: z.string().min(3, "Add a tonal cue."),
+  pacing: z.string().min(3, "Add pacing guidance."),
+});
+
+const draftSchema = z.object({
+  projectId: z.string().uuid(),
+  outlineId: z.string().uuid(),
+  notes: z.string().optional(),
+});
+
+export type OutlineDraftState = {
+  error?: string;
+  outline?: Outline;
+  draft?: string;
+};
+
+async function requireProjectOwner(projectId: string, userId?: string) {
+  const project = await getProjectByIdWithAccess({ id: projectId, userId });
+
+  if (!project) {
+    throw new ChatSDKError(
+      "not_found:api",
+      "Project not found or you do not have access."
+    );
+  }
+
+  if (project.userId !== userId) {
+    throw new ChatSDKError(
+      "forbidden:api",
+      "Only the project owner can update outlines."
+    );
+  }
+
+  return project;
+}
+
+export async function generateOutlineAction(
+  _prevState: OutlineDraftState,
+  formData: FormData
+): Promise<OutlineDraftState> {
+  const session = await auth();
+
+  if (!session) {
+    redirect("/api/auth/guest");
+  }
+
+  const parsed = outlineSchema.safeParse({
+    projectId: formData.get("projectId"),
+    title: formData.get("title"),
+    idea: formData.get("idea"),
+    pov: formData.get("pov"),
+    tone: formData.get("tone"),
+    pacing: formData.get("pacing"),
+  });
+
+  if (!parsed.success) {
+    return {
+      error: parsed.error.errors.map((issue) => issue.message).join(" "),
+    };
+  }
+
+  try {
+    await requireProjectOwner(parsed.data.projectId, session.user?.id);
+
+    const [entities, attributes, relationships] = await Promise.all([
+      getEntitiesForProject({ projectId: parsed.data.projectId }),
+      getAttributesForProject({ projectId: parsed.data.projectId }),
+      getRelationshipsForProject({ projectId: parsed.data.projectId }),
+    ]);
+
+    const loreContext = buildLoreContext({
+      entities,
+      attributes,
+      relationships,
+    });
+
+    const { text } = await generateText({
+      model: myProvider.languageModel("artifact-model"),
+      system:
+        "You plan detailed story outlines for fiction drafts. Keep responses concise, numbered, and aligned to supplied tone and pacing.",
+      prompt: `Story idea: ${parsed.data.idea}\nPoint of view: ${parsed.data.pov}\nTone: ${parsed.data.tone}\nPacing: ${parsed.data.pacing}\n\n${loreContext}\n\nReturn a numbered list of beats with one sentence each.`,
+    });
+
+    const beats = extractBeatsFromText(text);
+
+    const outline = await createOutline({
+      projectId: parsed.data.projectId,
+      title: parsed.data.title,
+      summary: parsed.data.idea,
+      pov: parsed.data.pov,
+      tone: parsed.data.tone,
+      pacing: parsed.data.pacing,
+      beats,
+    });
+
+    revalidatePath(`/projects/${parsed.data.projectId}/drafts`);
+
+    return { outline };
+  } catch (error) {
+    const chatError = error instanceof ChatSDKError ? error : null;
+    return {
+      error:
+        chatError?.message ??
+        "Unable to generate an outline right now. Please try again.",
+    };
+  }
+}
+
+export async function generateDraftAction(
+  _prevState: OutlineDraftState,
+  formData: FormData
+): Promise<OutlineDraftState> {
+  const session = await auth();
+
+  if (!session) {
+    redirect("/api/auth/guest");
+  }
+
+  const parsed = draftSchema.safeParse({
+    projectId: formData.get("projectId"),
+    outlineId: formData.get("outlineId"),
+    notes: formData.get("notes") ?? undefined,
+  });
+
+  if (!parsed.success) {
+    return {
+      error: parsed.error.errors.map((issue) => issue.message).join(" "),
+    };
+  }
+
+  try {
+    await requireProjectOwner(parsed.data.projectId, session.user?.id);
+
+    const outline = await getOutlineById({ id: parsed.data.outlineId });
+
+    if (!outline || outline.projectId !== parsed.data.projectId) {
+      throw new ChatSDKError(
+        "not_found:api",
+        "Outline not found for this project."
+      );
+    }
+
+    const [entities, attributes, relationships] = await Promise.all([
+      getEntitiesForProject({ projectId: parsed.data.projectId }),
+      getAttributesForProject({ projectId: parsed.data.projectId }),
+      getRelationshipsForProject({ projectId: parsed.data.projectId }),
+    ]);
+
+    const loreContext = buildLoreContext({
+      entities,
+      attributes,
+      relationships,
+    });
+
+    const outlinePrompt = outlineToPrompt(outline);
+    const noteSection = parsed.data.notes
+      ? `Additional notes to weave in: ${parsed.data.notes}`
+      : "";
+
+    const { text } = await generateText({
+      model: myProvider.languageModel("artifact-model"),
+      system:
+        "You are drafting narrative prose that follows a provided outline while respecting project lore. Keep continuity with entities and relationships and write in clear paragraphs.",
+      prompt: `${outlinePrompt}\n\n${loreContext}\n${noteSection}\n\nWrite the opening draft that stays aligned to the outline beats.`,
+    });
+
+    return { draft: text, outline };
+  } catch (error) {
+    const chatError = error instanceof ChatSDKError ? error : null;
+    return {
+      error:
+        chatError?.message ??
+        "Unable to generate a draft right now. Please try again.",
+    };
+  }
+}

--- a/app/(chat)/projects/[id]/drafts/page.tsx
+++ b/app/(chat)/projects/[id]/drafts/page.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { auth } from "@/app/(auth)/auth";
+import { Button } from "@/components/ui/button";
+import {
+  getOutlinesForProject,
+  getProjectByIdWithAccess,
+} from "@/lib/db/queries";
+import type { Outline } from "@/lib/db/schema";
+import { DraftWorkspace } from "./workspace";
+
+export default async function DraftsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await auth();
+
+  if (!session) {
+    redirect("/api/auth/guest");
+  }
+
+  const project = await getProjectByIdWithAccess({
+    id,
+    userId: session.user?.id,
+  });
+
+  if (!project) {
+    notFound();
+  }
+
+  const outlines: Outline[] = await getOutlinesForProject({
+    projectId: project.id,
+  });
+
+  const canEdit =
+    session.user?.type === "regular" && session.user?.id === project.userId;
+
+  return (
+    <div className="flex min-h-dvh flex-col gap-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <p className="text-muted-foreground text-sm">Project</p>
+          <h1 className="font-semibold text-3xl leading-tight">
+            {project.name}
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Ground drafts and outlines with your lore entities.
+          </p>
+        </div>
+        <Button asChild variant="outline">
+          <Link href={`/projects/${project.id}`}>Back to project</Link>
+        </Button>
+      </div>
+
+      <DraftWorkspace
+        canEdit={canEdit}
+        outlines={outlines}
+        projectId={project.id}
+        visibility={project.visibility}
+      />
+    </div>
+  );
+}

--- a/app/(chat)/projects/[id]/drafts/workspace.tsx
+++ b/app/(chat)/projects/[id]/drafts/workspace.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+import { useActionState, useEffect, useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import type { Outline } from "@/lib/db/schema";
+import { cn } from "@/lib/utils";
+import {
+  type OutlineDraftState,
+  generateDraftAction,
+  generateOutlineAction,
+} from "./actions";
+
+const POV_OPTIONS = [
+  "First person, intimate",
+  "Close third person",
+  "Limited omniscient",
+  "Cinematic objective",
+];
+
+const TONE_OPTIONS = [
+  "Optimistic and bright",
+  "Somber and restrained",
+  "Playful and witty",
+  "Tense and foreboding",
+];
+
+const PACING_OPTIONS = [
+  "Slow burn with reflection",
+  "Balanced with rising tension",
+  "Fast-paced and urgent",
+];
+
+export function DraftWorkspace({
+  canEdit,
+  outlines,
+  projectId,
+  visibility,
+}: {
+  canEdit: boolean;
+  outlines: Outline[];
+  projectId: string;
+  visibility: string;
+}) {
+  const [savedOutlines, setSavedOutlines] = useState(outlines);
+  const [activeOutlineId, setActiveOutlineId] = useState(
+    outlines.at(0)?.id ?? ""
+  );
+  const [aiDraft, setAiDraft] = useState("");
+  const [editableDraft, setEditableDraft] = useState("");
+
+  const [outlineState, generateOutline] = useActionState<
+    OutlineDraftState,
+    FormData
+  >(generateOutlineAction, {});
+  const [draftState, generateDraft] = useActionState<
+    OutlineDraftState,
+    FormData
+  >(generateDraftAction, {});
+
+  const activeOutline = useMemo(
+    () => savedOutlines.find((outline) => outline.id === activeOutlineId),
+    [activeOutlineId, savedOutlines]
+  );
+
+  useEffect(() => {
+    const newOutline = outlineState.outline;
+
+    if (!newOutline) {
+      return;
+    }
+
+    setSavedOutlines((previous) => {
+      const withoutDuplicate = previous.filter(
+        (outline) => outline.id !== newOutline.id
+      );
+
+      return [newOutline, ...withoutDuplicate];
+    });
+    setActiveOutlineId(newOutline.id);
+  }, [outlineState.outline]);
+
+  useEffect(() => {
+    if (draftState.draft) {
+      setAiDraft(draftState.draft);
+      setEditableDraft(draftState.draft);
+    }
+  }, [draftState]);
+
+  const outlineError = outlineState.error;
+  const draftError = draftState.error;
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1.1fr_1fr]">
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-xl">
+              Outline generator
+              <Badge variant="outline">{visibility}</Badge>
+            </CardTitle>
+            <p className="text-muted-foreground text-sm">
+              Guide the AI with point of view, tone, and pacing to keep your
+              chapters consistent.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <form
+              action={canEdit ? generateOutline : undefined}
+              className="space-y-4"
+            >
+              <input name="projectId" type="hidden" value={projectId} />
+              <div className="space-y-2">
+                <Label htmlFor="title">Outline title</Label>
+                <Input
+                  defaultValue="New chapter outline"
+                  disabled={!canEdit}
+                  id="title"
+                  name="title"
+                  placeholder="Chapter title or scene label"
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="idea">Premise or scene idea</Label>
+                <Textarea
+                  disabled={!canEdit}
+                  id="idea"
+                  minLength={12}
+                  name="idea"
+                  placeholder="Summarize the beats you want to cover"
+                  required
+                />
+              </div>
+              <div className="grid gap-4 md:grid-cols-3">
+                <div className="space-y-2">
+                  <Label>Point of view</Label>
+                  <Select defaultValue={POV_OPTIONS[1]} name="pov" disabled={!canEdit}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select POV" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {POV_OPTIONS.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {option}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Tone</Label>
+                  <Select defaultValue={TONE_OPTIONS[0]} name="tone" disabled={!canEdit}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Choose a tone" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {TONE_OPTIONS.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {option}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Pacing</Label>
+                  <Select defaultValue={PACING_OPTIONS[1]} name="pacing" disabled={!canEdit}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Pick pacing" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PACING_OPTIONS.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {option}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <Button disabled={!canEdit} type="submit">
+                  Generate outline
+                </Button>
+                {outlineError ? (
+                  <p className="text-destructive text-sm">{outlineError}</p>
+                ) : null}
+              </div>
+            </form>
+
+            <div className="space-y-2">
+              <p className="font-medium">Outline beats</p>
+              <div className="rounded-lg border bg-muted/30 p-4">
+                {activeOutline?.beats?.length ? (
+                  <ol className="space-y-2 text-sm">
+                    {activeOutline.beats.map((beat, index) => (
+                      <li key={beat + index} className="leading-relaxed">
+                        <span className="font-semibold text-muted-foreground">
+                          {index + 1}.
+                        </span>{" "}
+                        {beat}
+                      </li>
+                    ))}
+                  </ol>
+                ) : (
+                  <p className="text-muted-foreground text-sm">
+                    No outline generated yet. Create one to view its beats here.
+                  </p>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Saved outlines</CardTitle>
+            <p className="text-muted-foreground text-sm">
+              Reuse previous outlines across drafts. Newest items appear first.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {savedOutlines.length === 0 ? (
+              <p className="text-muted-foreground text-sm">
+                Outlines will show up here after you generate them.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {savedOutlines.map((outline) => (
+                  <button
+                    key={outline.id}
+                    className={cn(
+                      "w-full rounded-lg border px-3 py-2 text-left transition hover:border-primary",
+                      outline.id === activeOutlineId
+                        ? "border-primary bg-primary/5"
+                        : "border-border"
+                    )}
+                    onClick={() => setActiveOutlineId(outline.id)}
+                    type="button"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <div>
+                        <p className="font-medium leading-tight">{outline.title}</p>
+                        <p className="text-muted-foreground text-xs">
+                          {outline.pov} • {outline.tone}
+                        </p>
+                      </div>
+                      <Badge variant="outline">{outline.pacing}</Badge>
+                    </div>
+                    {outline.summary ? (
+                      <p className="text-muted-foreground mt-1 line-clamp-2 text-xs">
+                        {outline.summary}
+                      </p>
+                    ) : null}
+                  </button>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Draft generation</CardTitle>
+            <p className="text-muted-foreground text-sm">
+              Use a saved outline and your lore to draft prose side by side with
+              an editable version.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <form
+              action={canEdit ? generateDraft : undefined}
+              className="grid gap-4"
+            >
+              <input name="projectId" type="hidden" value={projectId} />
+              <div className="space-y-2">
+                <Label>Use outline</Label>
+                <Select
+                  value={activeOutlineId}
+                  disabled={!canEdit || savedOutlines.length === 0}
+                  name="outlineId"
+                  onValueChange={setActiveOutlineId}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select an outline" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {savedOutlines.map((outline) => (
+                      <SelectItem key={outline.id} value={outline.id}>
+                        {outline.title}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="notes">Notes for this draft</Label>
+                <Textarea
+                  disabled={!canEdit}
+                  id="notes"
+                  name="notes"
+                  placeholder="Add reminders, twists, or character goals"
+                />
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <Button
+                  disabled={!canEdit || savedOutlines.length === 0}
+                  type="submit"
+                >
+                  Generate draft
+                </Button>
+                {draftError ? (
+                  <p className="text-destructive text-sm">{draftError}</p>
+                ) : null}
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">AI output</CardTitle>
+              <p className="text-muted-foreground text-sm">
+                Generated text that respects your outline and lore.
+              </p>
+            </CardHeader>
+            <CardContent>
+              <div className="h-72 rounded-lg border bg-muted/40 p-3 text-sm leading-relaxed">
+                {aiDraft ? (
+                  <pre className="whitespace-pre-wrap text-left">
+                    {aiDraft}
+                  </pre>
+                ) : (
+                  <p className="text-muted-foreground">
+                    Generate a draft to see the AI suggestion.
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Editable draft</CardTitle>
+              <p className="text-muted-foreground text-sm">
+                Start from the AI output or write your own version alongside it.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Textarea
+                className="min-h-[18rem]"
+                disabled={!canEdit}
+                name="draft-content"
+                onChange={(event) => setEditableDraft(event.target.value)}
+                placeholder="Edit or expand the generated draft"
+                value={editableDraft}
+              />
+              <Button
+                disabled={!canEdit || !aiDraft}
+                onClick={() => setEditableDraft(aiDraft)}
+                type="button"
+                variant="outline"
+              >
+                Use AI text as draft
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(chat)/projects/[id]/page.tsx
+++ b/app/(chat)/projects/[id]/page.tsx
@@ -142,6 +142,22 @@ export default async function ProjectDetailPage({
       )}
 
       <Card>
+        <CardHeader className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <CardTitle className="text-lg">Draft workspace</CardTitle>
+            <p className="text-muted-foreground text-sm">
+              Generate outlines and drafts grounded in your entities and relationships.
+            </p>
+          </div>
+          <Button asChild size="sm" variant="default">
+            <Link href={`/projects/${project.id}/drafts`}>
+              Open draft workspace
+            </Link>
+          </Button>
+        </CardHeader>
+      </Card>
+
+      <Card>
         <CardHeader>
           <CardTitle className="text-lg">Project folders</CardTitle>
         </CardHeader>

--- a/lib/db/migrations/0010_outline_table.sql
+++ b/lib/db/migrations/0010_outline_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "Outline" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    "createdAt" timestamp NOT NULL,
+    "updatedAt" timestamp NOT NULL,
+    "title" text NOT NULL,
+    "summary" text,
+    "pov" varchar NOT NULL,
+    "tone" varchar NOT NULL,
+    "pacing" varchar NOT NULL,
+    "beats" jsonb,
+    "projectId" uuid NOT NULL,
+    CONSTRAINT "Outline_projectId_Project_id_fk" FOREIGN KEY ("projectId") REFERENCES "Project"("id")
+);

--- a/lib/db/migrations/meta/0010_snapshot.json
+++ b/lib/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1029 @@
+{
+  "id": "d50b2ac8-4846-455b-ad0c-64f952427285",
+  "prevId": "e6e96865-c492-4de5-8c6f-3d88d08f91c3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "lastContext": {
+          "name": "lastContext",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": [
+            "id",
+            "createdAt"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Message_v2": {
+      "name": "Message_v2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_v2_chatId_Chat_id_fk": {
+          "name": "Message_v2_chatId_Chat_id_fk",
+          "tableFrom": "Message_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Stream": {
+      "name": "Stream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Stream_chatId_Chat_id_fk": {
+          "name": "Stream_chatId_Chat_id_fk",
+          "tableFrom": "Stream",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Stream_id_pk": {
+          "name": "Stream_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "documentId",
+            "documentCreatedAt"
+          ],
+          "columnsTo": [
+            "id",
+            "createdAt"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Vote_v2": {
+      "name": "Vote_v2",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_v2_chatId_Chat_id_fk": {
+          "name": "Vote_v2_chatId_Chat_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_v2_messageId_Message_v2_id_fk": {
+          "name": "Vote_v2_messageId_Message_v2_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Message_v2",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_v2_chatId_messageId_pk": {
+          "name": "Vote_v2_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Project": {
+      "name": "Project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "folders": {
+          "name": "folders",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Project_userId_User_id_fk": {
+          "name": "Project_userId_User_id_fk",
+          "tableFrom": "Project",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Entity": {
+      "name": "Entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entity_name_project_idx": {
+          "name": "entity_name_project_idx",
+          "columns": [
+            "projectId",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "Entity_projectId_Project_id_fk": {
+          "name": "Entity_projectId_Project_id_fk",
+          "tableFrom": "Entity",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.EntityAttribute": {
+      "name": "EntityAttribute",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataType": {
+          "name": "dataType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entity_attribute_name_idx": {
+          "name": "entity_attribute_name_idx",
+          "columns": [
+            "entityId",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "EntityAttribute_entityId_Entity_id_fk": {
+          "name": "EntityAttribute_entityId_Entity_id_fk",
+          "tableFrom": "EntityAttribute",
+          "tableTo": "Entity",
+          "columnsFrom": [
+            "entityId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "EntityAttribute_projectId_Project_id_fk": {
+          "name": "EntityAttribute_projectId_Project_id_fk",
+          "tableFrom": "EntityAttribute",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Relationship": {
+      "name": "Relationship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceEntityId": {
+          "name": "sourceEntityId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetEntityId": {
+          "name": "targetEntityId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "relationship_unique_idx": {
+          "name": "relationship_unique_idx",
+          "columns": [
+            "projectId",
+            "sourceEntityId",
+            "targetEntityId",
+            "type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "Relationship_projectId_Project_id_fk": {
+          "name": "Relationship_projectId_Project_id_fk",
+          "tableFrom": "Relationship",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Relationship_sourceEntityId_Entity_id_fk": {
+          "name": "Relationship_sourceEntityId_Entity_id_fk",
+          "tableFrom": "Relationship",
+          "tableTo": "Entity",
+          "columnsFrom": [
+            "sourceEntityId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Relationship_targetEntityId_Entity_id_fk": {
+          "name": "Relationship_targetEntityId_Entity_id_fk",
+          "tableFrom": "Relationship",
+          "tableTo": "Entity",
+          "columnsFrom": [
+            "targetEntityId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Outline": {
+      "name": "Outline",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pov": {
+          "name": "pov",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone": {
+          "name": "tone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pacing": {
+          "name": "pacing",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beats": {
+          "name": "beats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Outline_projectId_Project_id_fk": {
+          "name": "Outline_projectId_Project_id_fk",
+          "tableFrom": "Outline",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1764979916681,
       "tag": "0009_entity_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1764982916681,
+      "tag": "0010_outline_table",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -30,6 +30,8 @@ import {
   document,
   type Entity,
   type EntityAttribute,
+  outline,
+  type Outline,
   message,
   project,
   relationship,
@@ -728,6 +730,25 @@ export async function getEntitiesForProject({
   }
 }
 
+export async function getAttributesForProject({
+  projectId,
+}: {
+  projectId: string;
+}): Promise<EntityAttribute[]> {
+  try {
+    return await db
+      .select()
+      .from(entityAttribute)
+      .where(eq(entityAttribute.projectId, projectId))
+      .orderBy(asc(entityAttribute.name));
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to load attributes for project"
+    );
+  }
+}
+
 export async function getEntityById({
   id,
 }: {
@@ -1032,6 +1053,87 @@ export async function getProjectByIdWithAccess({
     throw new ChatSDKError(
       "bad_request:database",
       "Failed to load project by id"
+    );
+  }
+}
+
+export async function createOutline({
+  projectId,
+  title,
+  summary,
+  pov,
+  tone,
+  pacing,
+  beats,
+}: {
+  projectId: string;
+  title: string;
+  summary?: string;
+  pov: string;
+  tone: string;
+  pacing: string;
+  beats: string[];
+}): Promise<Outline> {
+  try {
+    const [createdOutline] = await db
+      .insert(outline)
+      .values({
+        projectId,
+        title,
+        summary,
+        pov,
+        tone,
+        pacing,
+        beats,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .returning();
+
+    return createdOutline;
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to save outline"
+    );
+  }
+}
+
+export async function getOutlinesForProject({
+  projectId,
+}: {
+  projectId: string;
+}): Promise<Outline[]> {
+  try {
+    return await db
+      .select()
+      .from(outline)
+      .where(eq(outline.projectId, projectId))
+      .orderBy(desc(outline.updatedAt));
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to load outlines"
+    );
+  }
+}
+
+export async function getOutlineById({
+  id,
+}: {
+  id: string;
+}): Promise<Outline | null> {
+  try {
+    const [selectedOutline] = await db
+      .select()
+      .from(outline)
+      .where(eq(outline.id, id));
+
+    return selectedOutline ?? null;
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to load outline"
     );
   }
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -212,6 +212,23 @@ export const relationship = pgTable(
 
 export type Relationship = InferSelectModel<typeof relationship>;
 
+export const outline = pgTable("Outline", {
+  id: uuid("id").primaryKey().notNull().defaultRandom(),
+  createdAt: timestamp("createdAt").notNull(),
+  updatedAt: timestamp("updatedAt").notNull(),
+  title: text("title").notNull(),
+  summary: text("summary"),
+  pov: varchar("pov", { length: 64 }).notNull(),
+  tone: varchar("tone", { length: 64 }).notNull(),
+  pacing: varchar("pacing", { length: 64 }).notNull(),
+  beats: jsonb("beats").$type<string[] | null>(),
+  projectId: uuid("projectId")
+    .notNull()
+    .references(() => project.id),
+});
+
+export type Outline = InferSelectModel<typeof outline>;
+
 export const document = pgTable(
   "Document",
   {

--- a/lib/story/lore.ts
+++ b/lib/story/lore.ts
@@ -1,0 +1,101 @@
+import type {
+  Entity,
+  EntityAttribute,
+  Outline,
+  Relationship,
+} from "@/lib/db/schema";
+
+function cleanLine(line: string): string {
+  return line.replace(/^[-*\d.\s]+/, "").trim();
+}
+
+export function extractBeatsFromText(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => cleanLine(line))
+    .filter((line) => line.length > 0);
+}
+
+export function buildLoreContext({
+  entities,
+  attributes,
+  relationships,
+}: {
+  entities: Entity[];
+  attributes: EntityAttribute[];
+  relationships: Relationship[];
+}): string {
+  if (entities.length === 0 && relationships.length === 0) {
+    return "Lore: No structured entities were defined for this project yet.";
+  }
+
+  const attributeMap = new Map<string, EntityAttribute[]>();
+  const entityNameMap = new Map<string, string>();
+
+  attributes.forEach((attribute) => {
+    const existingAttributes = attributeMap.get(attribute.entityId) ?? [];
+    attributeMap.set(attribute.entityId, [...existingAttributes, attribute]);
+  });
+
+  entities.forEach((entityItem) => {
+    entityNameMap.set(entityItem.id, entityItem.name);
+  });
+
+  const entityLines = entities.map((entityItem) => {
+    const attributesForEntity = attributeMap.get(entityItem.id) ?? [];
+    const attributeSummary = attributesForEntity
+      .map((attribute) => `${attribute.name}: ${attribute.value}`)
+      .join("; ");
+
+    const summary = entityItem.summary ?? "No summary yet";
+
+    if (attributeSummary.length > 0) {
+      return `- ${entityItem.name} (${entityItem.kind}): ${summary}. Traits: ${attributeSummary}`;
+    }
+
+    return `- ${entityItem.name} (${entityItem.kind}): ${summary}`;
+  });
+
+  const relationshipLines = relationships.map(
+    (relationshipItem) =>
+      `- ${relationshipItem.type} between ${
+        entityNameMap.get(relationshipItem.sourceEntityId) ??
+        relationshipItem.sourceEntityId
+      } and ${
+        entityNameMap.get(relationshipItem.targetEntityId) ??
+        relationshipItem.targetEntityId
+      }: ${relationshipItem.description ?? "No relationship details provided."}`
+  );
+
+  return [
+    "Lore entities:",
+    entityLines.join("\n"),
+    relationshipLines.length > 0
+      ? `Relationships:\n${relationshipLines.join("\n")}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function outlineToPrompt(outline: Outline): string {
+  const beats = outline.beats?.length
+    ? outline.beats
+    : outline.summary
+      ? [outline.summary]
+      : [];
+
+  const numberedBeats = beats
+    .map((beat, index) => `${index + 1}. ${beat}`)
+    .join("\n");
+
+  return [
+    `Title: ${outline.title}`,
+    `Point of view: ${outline.pov}`,
+    `Tone: ${outline.tone}`,
+    `Pacing: ${outline.pacing}`,
+    beats.length > 0 ? `Outline:\n${numberedBeats}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}

--- a/tests/routes/lore-context.test.ts
+++ b/tests/routes/lore-context.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  buildLoreContext,
+  extractBeatsFromText,
+  outlineToPrompt,
+} from "@/lib/story/lore";
+
+const baseDate = new Date("2024-01-01T00:00:00.000Z");
+
+const guardian = {
+  id: "guardian-id",
+  createdAt: baseDate,
+  updatedAt: baseDate,
+  name: "Aria",
+  kind: "Guardian",
+  summary: "Protector of the capital",
+  startDate: null,
+  endDate: null,
+  projectId: "project-id",
+};
+
+const prince = {
+  id: "prince-id",
+  createdAt: baseDate,
+  updatedAt: baseDate,
+  name: "Cassian",
+  kind: "Prince",
+  summary: "Heir torn between duty and rebellion",
+  startDate: null,
+  endDate: null,
+  projectId: "project-id",
+};
+
+test("buildLoreContext lists entities and relationship names", () => {
+  const lore = buildLoreContext({
+    entities: [guardian, prince],
+    attributes: [
+      {
+        id: "att-1",
+        createdAt: baseDate,
+        name: "Virtue",
+        value: "Loyal to the oath",
+        dataType: "text",
+        startDate: null,
+        endDate: null,
+        entityId: guardian.id,
+        projectId: guardian.projectId,
+      },
+    ],
+    relationships: [
+      {
+        id: "rel-1",
+        createdAt: baseDate,
+        type: "Allies",
+        description: "Secret alliance to avoid war",
+        startDate: null,
+        endDate: null,
+        projectId: guardian.projectId,
+        sourceEntityId: guardian.id,
+        targetEntityId: prince.id,
+      },
+    ],
+  });
+
+  expect(lore).toContain("Aria");
+  expect(lore).toContain("Cassian");
+  expect(lore).toContain("Allies");
+  expect(lore).toContain("Secret alliance to avoid war");
+});
+
+test("extractBeatsFromText cleans numbering and bullets", () => {
+  const beats = extractBeatsFromText(
+    `1. Open on the market square\n- Introduce the tension\n3) Reveal the prophecy`
+  );
+
+  expect(beats).toEqual([
+    "Open on the market square",
+    "Introduce the tension",
+    "Reveal the prophecy",
+  ]);
+});
+
+test("outlineToPrompt formats pacing and tone with beats", () => {
+  const prompt = outlineToPrompt({
+    id: "outline-1",
+    createdAt: baseDate,
+    updatedAt: baseDate,
+    title: "Chapter One",
+    summary: "",
+    pov: "Close third person",
+    tone: "Tense",
+    pacing: "Balanced",
+    beats: ["Arrival at the docks", "Uneasy meeting"],
+    projectId: guardian.projectId,
+  });
+
+  expect(prompt).toContain("Chapter One");
+  expect(prompt).toContain("Close third person");
+  expect(prompt).toContain("1. Arrival at the docks");
+  expect(prompt).toContain("Uneasy meeting");
+});


### PR DESCRIPTION
## Summary
- deduplicate saved outlines in the draft workspace and keep the newest outline selected when generated
- switch the draft workspace to use `useActionState` and document saved-outline ordering in the README

## Testing
- `pnpm run build` *(fails: database migrations cannot connect to the configured Postgres service in this environment)*
- `pnpm exec tsc --noEmit` *(fails: repository-wide type errors and missing module resolutions outside the changed files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69337a4ccf788325b60ac028f5700a6e)