### PR TITLE
Add rewrite selection prompts and version controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   - Generate outlines with POV, tone, and pacing controls and save them per project
   - Draft prose side-by-side with AI suggestions grounded in your lore entities
   - Saved outlines stay deduplicated and sorted by newest first in the draft workspace
+  - Highlight text to fire rewrite prompts, review AI rationales, and restore or diff auto-versioned drafts
 - [Auth.js](https://authjs.dev)
   - Simple and secure authentication
 

--- a/artifacts/text/client.tsx
+++ b/artifacts/text/client.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Artifact } from "@/components/create-artifact";
 import { DiffView } from "@/components/diffview";
@@ -11,7 +12,9 @@ import {
   UndoIcon,
 } from "@/components/icons";
 import { Editor } from "@/components/text-editor";
+import { Button } from "@/components/ui/button";
 import type { Suggestion } from "@/lib/db/schema";
+import { buildRewritePrompt, type RewriteIntent } from "@/lib/editor/rewrite";
 import { getSuggestions } from "../actions";
 
 type TextArtifactMetadata = {
@@ -63,7 +66,18 @@ export const textArtifact = new Artifact<"text", TextArtifactMetadata>({
     getDocumentContentById,
     isLoading,
     metadata,
+    sendMessage,
   }) => {
+    const [selectedText, setSelectedText] = useState<string>("");
+    const [lastPrompt, setLastPrompt] = useState<string>("");
+    const canRewriteSelection = isCurrentVersion && status === "idle";
+
+    useEffect(() => {
+      if (!canRewriteSelection) {
+        setSelectedText("");
+      }
+    }, [canRewriteSelection]);
+
     if (isLoading) {
       return <DocumentSkeleton artifactKind="text" />;
     }
@@ -76,11 +90,47 @@ export const textArtifact = new Artifact<"text", TextArtifactMetadata>({
     }
 
     return (
-      <div className="flex flex-row px-4 py-8 md:p-20">
+      <div className="flex flex-col gap-4 px-4 py-8 md:p-20">
+        {canRewriteSelection && selectedText ? (
+          <SelectionRewritePrompt
+            lastPrompt={lastPrompt}
+            onClearSelection={() => {
+              setSelectedText("");
+            }}
+            onPrompt={(intent) => {
+              const prompt = buildRewritePrompt({
+                selection: selectedText,
+                intent,
+              });
+
+              setLastPrompt(prompt);
+
+              sendMessage({
+                role: "user",
+                parts: [
+                  {
+                    type: "text",
+                    text: prompt,
+                  },
+                ],
+              });
+            }}
+            selection={selectedText}
+          />
+        ) : null}
+
         <Editor
           content={content}
           currentVersionIndex={currentVersionIndex}
           isCurrentVersion={isCurrentVersion}
+          onSelectionChange={(selectionText) => {
+            if (!canRewriteSelection) {
+              setSelectedText("");
+              return;
+            }
+
+            setSelectedText(selectionText);
+          }}
           onSaveContent={onSaveContent}
           status={status}
           suggestions={metadata ? metadata.suggestions : []}
@@ -177,3 +227,82 @@ export const textArtifact = new Artifact<"text", TextArtifactMetadata>({
     },
   ],
 });
+
+type SelectionRewritePromptProps = {
+  selection: string;
+  onPrompt: (intent: RewriteIntent) => void;
+  onClearSelection: () => void;
+  lastPrompt: string;
+};
+
+const rewriteIntents: { label: string; intent: RewriteIntent; helper: string }[] = [
+  {
+    label: "Rewrite",
+    intent: "rewrite",
+    helper: "Improve clarity and flow",
+  },
+  {
+    label: "Shorten",
+    intent: "shorten",
+    helper: "Make the selection concise",
+  },
+  {
+    label: "Expand",
+    intent: "expand",
+    helper: "Add richer detail",
+  },
+];
+
+const SelectionRewritePrompt = ({
+  selection,
+  onPrompt,
+  onClearSelection,
+  lastPrompt,
+}: SelectionRewritePromptProps) => {
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border bg-background/80 p-4 shadow-sm dark:border-zinc-700 dark:bg-muted/60">
+      <div className="flex flex-row items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <div className="font-medium">Rewrite selection</div>
+          <div className="text-muted-foreground text-sm">
+            Choose how you want the assistant to transform the highlighted text.
+          </div>
+        </div>
+
+        <Button onClick={onClearSelection} size="sm" variant="ghost">
+          Clear
+        </Button>
+      </div>
+
+      <div className="rounded-xl bg-muted p-3 text-sm dark:bg-background">
+        “{selection}”
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {rewriteIntents.map(({ label, intent, helper }) => (
+          <Button
+            key={intent}
+            className="flex-1 min-w-[140px] justify-between"
+            onClick={() => onPrompt(intent)}
+            type="button"
+            variant="outline"
+          >
+            <span className="text-left">
+              <div className="font-medium leading-tight">{label}</div>
+              <div className="text-muted-foreground text-xs">{helper}</div>
+            </span>
+          </Button>
+        ))}
+      </div>
+
+      {lastPrompt ? (
+        <div className="rounded-xl border bg-background/60 p-3 text-muted-foreground text-xs dark:border-zinc-700 dark:bg-muted/40">
+          Last rewrite request sent:
+          <div className="mt-1 line-clamp-3 font-medium text-foreground">
+            {lastPrompt}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/components/artifact.tsx
+++ b/components/artifact.tsx
@@ -25,6 +25,7 @@ import { ArtifactCloseButton } from "./artifact-close-button";
 import { ArtifactMessages } from "./artifact-messages";
 import { MultimodalInput } from "./multimodal-input";
 import { Toolbar } from "./toolbar";
+import { Badge } from "./ui/badge";
 import { useSidebar } from "./ui/sidebar";
 import { VersionFooter } from "./version-footer";
 import type { VisibilityType } from "./visibility-selector";
@@ -240,6 +241,11 @@ function PureArtifact({
       ? currentVersionIndex === documents.length - 1
       : true;
 
+  const versionCount = documents?.length ?? 1;
+  const draftPosition =
+    currentVersionIndex >= 0 ? currentVersionIndex + 1 : versionCount;
+  const versionLabel = `Draft ${draftPosition} of ${versionCount}`;
+
   const { width: windowWidth, height: windowHeight } = useWindowSize();
   const isMobile = windowWidth ? windowWidth < 768 : false;
 
@@ -422,26 +428,27 @@ function PureArtifact({
               <div className="flex flex-row items-start gap-4">
                 <ArtifactCloseButton />
 
-                <div className="flex flex-col">
+                <div className="flex flex-col gap-1">
                   <div className="font-medium">{artifact.title}</div>
 
-                  {isContentDirty ? (
-                    <div className="text-muted-foreground text-sm">
-                      Saving changes...
-                    </div>
-                  ) : document ? (
-                    <div className="text-muted-foreground text-sm">
-                      {`Updated ${formatDistance(
-                        new Date(document.createdAt),
-                        new Date(),
-                        {
-                          addSuffix: true,
-                        }
-                      )}`}
-                    </div>
-                  ) : (
-                    <div className="mt-2 h-3 w-32 animate-pulse rounded-md bg-muted-foreground/20" />
-                  )}
+                  <div className="flex flex-row flex-wrap items-center gap-2 text-muted-foreground text-sm">
+                    <Badge variant="outline">{versionLabel}</Badge>
+                    {isContentDirty ? (
+                      <div>Saving changes...</div>
+                    ) : document ? (
+                      <div>
+                        {`Updated ${formatDistance(
+                          new Date(document.createdAt),
+                          new Date(),
+                          {
+                            addSuffix: true,
+                          }
+                        )}`}
+                      </div>
+                    ) : (
+                      <div className="mt-2 h-3 w-32 animate-pulse rounded-md bg-muted-foreground/20" />
+                    )}
+                  </div>
                 </div>
               </div>
 
@@ -471,6 +478,7 @@ function PureArtifact({
                 metadata={metadata}
                 mode={mode}
                 onSaveContent={saveContent}
+                sendMessage={sendMessage}
                 setMetadata={setMetadata}
                 status={artifact.status}
                 suggestions={[]}
@@ -492,15 +500,16 @@ function PureArtifact({
               </AnimatePresence>
             </div>
 
-            <AnimatePresence>
-              {!isCurrentVersion && (
-                <VersionFooter
-                  currentVersionIndex={currentVersionIndex}
-                  documents={documents}
-                  handleVersionChange={handleVersionChange}
-                />
-              )}
-            </AnimatePresence>
+              <AnimatePresence>
+                {!isCurrentVersion && (
+                  <VersionFooter
+                    currentVersionIndex={currentVersionIndex}
+                    documents={documents}
+                    handleVersionChange={handleVersionChange}
+                    mode={mode}
+                  />
+                )}
+              </AnimatePresence>
           </motion.div>
         </motion.div>
       )}

--- a/components/create-artifact.tsx
+++ b/components/create-artifact.tsx
@@ -47,6 +47,7 @@ type ArtifactContent<M = any> = {
   isLoading: boolean;
   metadata: M;
   setMetadata: Dispatch<SetStateAction<M>>;
+  sendMessage: UseChatHelpers<ChatMessage>["sendMessage"];
 };
 
 type InitializeParameters<M = any> = {

--- a/components/suggestion.tsx
+++ b/components/suggestion.tsx
@@ -27,7 +27,7 @@ export const Suggestion = ({
       {isExpanded ? (
         <motion.div
           animate={{ opacity: 1, y: -20 }}
-          className="-right-12 md:-right-16 absolute z-50 flex w-56 flex-col gap-3 rounded-2xl border bg-background p-3 font-sans text-sm shadow-xl"
+          className="-right-12 md:-right-16 absolute z-50 flex w-64 flex-col gap-3 rounded-2xl border bg-background p-3 font-sans text-sm shadow-xl"
           exit={{ opacity: 0, y: -10 }}
           initial={{ opacity: 0, y: -10 }}
           key={suggestion.id}
@@ -49,7 +49,27 @@ export const Suggestion = ({
               <CrossIcon size={12} />
             </button>
           </div>
-          <div>{suggestion.description}</div>
+          <div className="flex flex-col gap-2">
+            <div>
+              <div className="text-muted-foreground text-xs uppercase tracking-wide">
+                Suggested edit
+              </div>
+              <div className="mt-1 rounded-lg bg-muted p-2 text-sm font-medium leading-relaxed dark:bg-background">
+                {suggestion.suggestedText}
+              </div>
+            </div>
+
+            {suggestion.description ? (
+              <div>
+                <div className="text-muted-foreground text-xs uppercase tracking-wide">
+                  Rationale
+                </div>
+                <div className="mt-1 rounded-lg bg-background p-2 leading-relaxed dark:bg-muted/40">
+                  {suggestion.description}
+                </div>
+              </div>
+            ) : null}
+          </div>
           <Button
             className="w-fit rounded-full px-3 py-1.5"
             onClick={onApply}

--- a/components/text-editor.tsx
+++ b/components/text-editor.tsx
@@ -30,6 +30,7 @@ type EditorProps = {
   isCurrentVersion: boolean;
   currentVersionIndex: number;
   suggestions: Suggestion[];
+  onSelectionChange?: (selectionText: string) => void;
 };
 
 function PureEditor({
@@ -37,6 +38,7 @@ function PureEditor({
   onSaveContent,
   suggestions,
   status,
+  onSelectionChange,
 }: EditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<EditorView | null>(null);
@@ -84,11 +86,12 @@ function PureEditor({
             transaction,
             editorRef,
             onSaveContent,
+            onSelectionChange,
           });
         },
       });
     }
-  }, [onSaveContent]);
+  }, [onSaveContent, onSelectionChange]);
 
   useEffect(() => {
     if (editorRef.current && content) {
@@ -157,7 +160,8 @@ function areEqual(prevProps: EditorProps, nextProps: EditorProps) {
     prevProps.isCurrentVersion === nextProps.isCurrentVersion &&
     !(prevProps.status === "streaming" && nextProps.status === "streaming") &&
     prevProps.content === nextProps.content &&
-    prevProps.onSaveContent === nextProps.onSaveContent
+    prevProps.onSaveContent === nextProps.onSaveContent &&
+    prevProps.onSelectionChange === nextProps.onSelectionChange
   );
 }
 

--- a/components/version-footer.tsx
+++ b/components/version-footer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { isAfter } from "date-fns";
+import { formatDistance, isAfter } from "date-fns";
 import { motion } from "framer-motion";
 import { useState } from "react";
 import { useSWRConfig } from "swr";
@@ -9,18 +9,21 @@ import { useArtifact } from "@/hooks/use-artifact";
 import type { Document } from "@/lib/db/schema";
 import { getDocumentTimestampByIndex } from "@/lib/utils";
 import { LoaderIcon } from "./icons";
+import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 
 type VersionFooterProps = {
   handleVersionChange: (type: "next" | "prev" | "toggle" | "latest") => void;
   documents: Document[] | undefined;
   currentVersionIndex: number;
+  mode: "edit" | "diff";
 };
 
 export const VersionFooter = ({
   handleVersionChange,
   documents,
   currentVersionIndex,
+  mode,
 }: VersionFooterProps) => {
   const { artifact } = useArtifact();
 
@@ -31,8 +34,11 @@ export const VersionFooter = ({
   const [isMutating, setIsMutating] = useState(false);
 
   if (!documents) {
-    return;
+    return null;
   }
+
+  const currentDocument = documents[currentVersionIndex];
+  const draftLabel = `Draft ${currentVersionIndex + 1} of ${documents.length}`;
 
   return (
     <motion.div
@@ -43,13 +49,33 @@ export const VersionFooter = ({
       transition={{ type: "spring", stiffness: 140, damping: 20 }}
     >
       <div>
-        <div>You are viewing a previous version</div>
-        <div className="text-muted-foreground text-sm">
-          Restore this version to make edits
+        <div className="flex flex-col gap-1">
+          <div className="flex flex-row flex-wrap items-center gap-2">
+            <Badge variant="outline">{draftLabel}</Badge>
+            {currentDocument?.createdAt ? (
+              <div className="text-muted-foreground text-sm">
+                Saved {" "}
+                {formatDistance(new Date(currentDocument.createdAt), new Date(), {
+                  addSuffix: true,
+                })}
+              </div>
+            ) : null}
+          </div>
+          <div className="text-muted-foreground text-sm">
+            You are viewing a previous version. Restore to keep editing.
+          </div>
         </div>
       </div>
 
       <div className="flex flex-row gap-4">
+        <Button
+          onClick={() => {
+            handleVersionChange("toggle");
+          }}
+          variant="outline"
+        >
+          {mode === "diff" ? "Exit diff" : "View diff"}
+        </Button>
         <Button
           disabled={isMutating}
           onClick={async () => {

--- a/lib/editor/config.ts
+++ b/lib/editor/config.ts
@@ -25,10 +25,12 @@ export const handleTransaction = ({
   transaction,
   editorRef,
   onSaveContent,
+  onSelectionChange,
 }: {
   transaction: Transaction;
   editorRef: MutableRefObject<EditorView | null>;
   onSaveContent: (updatedContent: string, debounce: boolean) => void;
+  onSelectionChange?: (selectionText: string) => void;
 }) => {
   if (!editorRef || !editorRef.current) {
     return;
@@ -45,5 +47,16 @@ export const handleTransaction = ({
     } else {
       onSaveContent(updatedContent, true);
     }
+  }
+
+  if (transaction.selectionSet && onSelectionChange) {
+    const { selection } = newState;
+    const selectedText = newState.doc.textBetween(
+      selection.from,
+      selection.to,
+      " "
+    );
+
+    onSelectionChange(selectedText.trim());
   }
 };

--- a/lib/editor/rewrite.ts
+++ b/lib/editor/rewrite.ts
@@ -1,0 +1,28 @@
+export type RewriteIntent = "rewrite" | "shorten" | "expand";
+
+export function buildRewritePrompt({
+  selection,
+  intent,
+}: {
+  selection: string;
+  intent: RewriteIntent;
+}): string {
+  const trimmedSelection = selection.trim();
+  const baseInstruction =
+    "You are refining a highlighted section of a larger document. Work only on the provided selection and keep the surrounding context intact.";
+
+  if (!trimmedSelection) {
+    return baseInstruction;
+  }
+
+  const intentInstruction = {
+    rewrite:
+      "Rewrite the selection to be clearer while preserving the author's intent.",
+    shorten:
+      "Condense the selection to be more concise without losing critical details.",
+    expand:
+      "Expand the selection with richer detail and smoother transitions without changing the core meaning.",
+  }[intent];
+
+  return `${baseInstruction}\n\n${intentInstruction}\n\nSelected text:\n"""${trimmedSelection}"""`;
+}

--- a/tests/prompts/rewrite.test.ts
+++ b/tests/prompts/rewrite.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+import { buildRewritePrompt } from "@/lib/editor/rewrite";
+
+const selection = "The valley's wind whispered loudly.";
+
+test.describe("rewrite prompt builder", () => {
+  test("includes intent-specific instructions", () => {
+    const prompt = buildRewritePrompt({ selection, intent: "rewrite" });
+
+    expect(prompt).toContain("Rewrite the selection");
+    expect(prompt).toContain(selection);
+  });
+
+  test("falls back to guidance when selection is empty", () => {
+    const prompt = buildRewritePrompt({ selection: "   ", intent: "shorten" });
+
+    expect(prompt).toContain("highlighted section");
+  });
+});


### PR DESCRIPTION
## Summary
- add a selection-aware rewrite prompt workflow for text artifacts and route prompts through chat
- show suggested edits alongside AI rationale and surface draft version badges and diff/revert controls
- cover rewrite prompt builder with a Playwright unit test

## Testing
- Not run (pnpm/npx unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f9d53e048325a8b0bb6dbfc6c2e7)