### PR TITLE
Include project relationships in chat prompt context

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -30,23 +30,24 @@ import { isProductionEnvironment } from "@/lib/constants";
 import {
   createStreamId,
   deleteChatById,
+  getAttributesForProject,
   getChatById,
+  getEntitiesForProject,
   getMessageCountByUserId,
   getMessagesByChatId,
   getProjectByIdWithAccess,
-  getEntitiesForProject,
-  getAttributesForProject,
+  getRelationshipsForProject,
   saveChat,
   saveMessages,
   updateChatLastContextById,
 } from "@/lib/db/queries";
 import type { DBMessage } from "@/lib/db/schema";
 import { ChatSDKError } from "@/lib/errors";
+import { buildProjectContext } from "@/lib/project-context";
 import type { ChatMessage } from "@/lib/types";
 import type { AppUsage } from "@/lib/usage";
 import { convertToUIMessages, generateUUID } from "@/lib/utils";
 import { generateTitleFromUserMessage } from "../../actions";
-import { buildProjectContextPrompt } from "@/lib/project-context";
 import { type PostRequestBody, postRequestBodySchema } from "./schema";
 
 export const maxDuration = 60;
@@ -131,18 +132,23 @@ export async function POST(request: Request) {
       });
 
       if (!project) {
-        return new ChatSDKError("forbidden:chat", "Project unavailable").toResponse();
+        return new ChatSDKError(
+          "forbidden:chat",
+          "Project unavailable"
+        ).toResponse();
       }
 
-      const [entities, attributes] = await Promise.all([
+      const [entities, attributes, relationships] = await Promise.all([
         getEntitiesForProject({ projectId }),
         getAttributesForProject({ projectId }),
+        getRelationshipsForProject({ projectId }),
       ]);
 
-      projectContext = buildProjectContextPrompt({
+      projectContext = buildProjectContext({
         project,
         entities,
         attributes,
+        relationships,
       });
     }
 

--- a/lib/project-context.ts
+++ b/lib/project-context.ts
@@ -3,7 +3,9 @@ import type {
   EntityAttribute,
   Project,
   ProjectFolder,
+  Relationship,
 } from "@/lib/db/schema";
+import { buildLoreContext } from "@/lib/story/lore";
 
 export type ProjectSummary = Pick<
   Project,
@@ -39,7 +41,9 @@ export function buildProjectContextPrompt({
   attributes: EntityAttribute[];
 }) {
   const folderLines = project.folders
-    .map((folder) => `- ${folder.name}: ${folder.description ?? "No description"}`)
+    .map(
+      (folder) => `- ${folder.name}: ${folder.description ?? "No description"}`
+    )
     .join("\n");
 
   const attributesByEntity = attributes.reduce<Record<string, string[]>>(
@@ -70,4 +74,35 @@ export function buildProjectContextPrompt({
   ].filter(Boolean);
 
   return descriptions.join("\n\n");
+}
+
+/**
+ * Builds a richer project context string that combines the project summary
+ * with lore details (entities, attributes, and relationships) for use in
+ * grounding chat prompts.
+ */
+export function buildProjectContext({
+  project,
+  entities,
+  attributes,
+  relationships,
+}: {
+  project: Project;
+  entities: Entity[];
+  attributes: EntityAttribute[];
+  relationships: Relationship[];
+}): string {
+  const projectSummary = buildProjectContextPrompt({
+    project,
+    entities,
+    attributes,
+  });
+
+  const loreContext = buildLoreContext({
+    entities,
+    attributes,
+    relationships,
+  });
+
+  return [projectSummary, loreContext].filter(Boolean).join("\n\n");
 }

--- a/lib/story/lore.ts
+++ b/lib/story/lore.ts
@@ -5,8 +5,10 @@ import type {
   Relationship,
 } from "@/lib/db/schema";
 
+const LEADING_MARKER_REGEX = /^[-*()\d.\s]+/;
+
 function cleanLine(line: string): string {
-  return line.replace(/^[-*\d.\s]+/, "").trim();
+  return line.replace(LEADING_MARKER_REGEX, "").trim();
 }
 
 export function extractBeatsFromText(text: string): string[] {

--- a/tests/routes/chat-context.test.ts
+++ b/tests/routes/chat-context.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+
+import { DEFAULT_PROJECT_FOLDERS } from "@/lib/constants";
+import { buildProjectContext } from "@/lib/project-context";
+
+const baseDate = new Date("2024-01-01T00:00:00.000Z");
+
+const project = {
+  id: "project-id",
+  createdAt: baseDate,
+  name: "Lorebook",
+  description: "A universe for relational prompts",
+  visibility: "private" as const,
+  folders: DEFAULT_PROJECT_FOLDERS,
+  userId: "user-id",
+};
+
+const guardian = {
+  id: "guardian-id",
+  createdAt: baseDate,
+  updatedAt: baseDate,
+  name: "Aria",
+  kind: "Guardian",
+  summary: "Protector of the capital",
+  startDate: null,
+  endDate: null,
+  projectId: project.id,
+};
+
+const prince = {
+  id: "prince-id",
+  createdAt: baseDate,
+  updatedAt: baseDate,
+  name: "Cassian",
+  kind: "Prince",
+  summary: "Heir torn between duty and rebellion",
+  startDate: null,
+  endDate: null,
+  projectId: project.id,
+};
+
+test("relationship context is merged into chat prompts when a project is selected", () => {
+  const projectContext = buildProjectContext({
+    project,
+    entities: [guardian, prince],
+    attributes: [
+      {
+        id: "att-1",
+        createdAt: baseDate,
+        name: "Virtue",
+        value: "Loyal to the oath",
+        dataType: "text",
+        startDate: null,
+        endDate: null,
+        entityId: guardian.id,
+        projectId: project.id,
+      },
+    ],
+    relationships: [
+      {
+        id: "rel-1",
+        createdAt: baseDate,
+        type: "Allies",
+        description: "Secret alliance to avoid war",
+        startDate: null,
+        endDate: null,
+        projectId: project.id,
+        sourceEntityId: guardian.id,
+        targetEntityId: prince.id,
+      },
+    ],
+  });
+
+  const groundedPrompt = `Base system prompt\n\nProject context:\n${projectContext}`;
+
+  expect(groundedPrompt).toContain("Relationships:");
+  expect(groundedPrompt).toContain("Allies between Aria and Cassian");
+  expect(groundedPrompt).toContain("Virtue: Loyal to the oath");
+});


### PR DESCRIPTION
## Summary
- fetch project relationships when building the chat project context and merge them into the prompt payload
- add a helper to combine project metadata with lore context and normalize beat parsing for numbered lines
- add regression coverage ensuring relationship details flow into the chat prompt context

## Testing
- pnpm format *(fails: existing lint issues reported by ultracite)*
- pnpm lint *(fails: existing lint issues reported by ultracite)*
- pnpm test *(fails: dev server authentication error when creating guest user)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693414855878832588c1e5b7573cbdf5)