### PR TITLE
Add storytelling system prompt for project chats

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -242,6 +242,8 @@ export async function POST(request: Request) {
     const baseSystemPrompt = systemPrompt({
       selectedChatModel,
       requestHints,
+      hasProjectContext: Boolean(projectContext),
+      usesStoryTools: Boolean(projectId),
     });
 
     const groundedSystemPrompt = projectContext

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -35,6 +35,10 @@ Do not update document right after creating it. Wait for user feedback or reques
 export const regularPrompt =
   "You are a friendly assistant! Keep your responses concise and helpful.";
 
+const storytellingPrompt = `
+You are a narrative-focused writing assistant. Ground every reply in the provided lore and entity relationships to maintain character, setting, and timeline continuity. When planning or drafting chapters, propose clear beats before prose and preserve the established point of view, tone, and pacing. If details are missing, ask for them instead of inventing new canon.
+`;
+
 export type RequestHints = {
   latitude: Geo["latitude"];
   longitude: Geo["longitude"];
@@ -53,17 +57,30 @@ About the origin of user's request:
 export const systemPrompt = ({
   selectedChatModel,
   requestHints,
+  hasProjectContext = false,
+  usesStoryTools = false,
 }: {
   selectedChatModel: string;
   requestHints: RequestHints;
+  hasProjectContext?: boolean;
+  usesStoryTools?: boolean;
 }) => {
   const requestPrompt = getRequestPromptFromHints(requestHints);
+  const isStoryMode = hasProjectContext || usesStoryTools;
+  const personaPrompt = isStoryMode ? storytellingPrompt : regularPrompt;
+  const loreAvailabilityPrompt = isStoryMode
+    ? hasProjectContext
+      ? "Project lore context is provided below. Keep character continuity, relationships, and chapter pacing aligned with it."
+      : "When lore context is provided, keep continuity across characters, relationships, and chapters instead of inventing new canon."
+    : "";
 
-  if (selectedChatModel === "chat-model-reasoning") {
-    return `${regularPrompt}\n\n${requestPrompt}`;
+  const promptSections = [personaPrompt, loreAvailabilityPrompt, requestPrompt];
+
+  if (selectedChatModel !== "chat-model-reasoning") {
+    promptSections.push(artifactsPrompt);
   }
 
-  return `${regularPrompt}\n\n${requestPrompt}\n\n${artifactsPrompt}`;
+  return promptSections.filter(Boolean).join("\n\n");
 };
 
 export const codePrompt = `

--- a/tests/prompts/system-prompt.test.ts
+++ b/tests/prompts/system-prompt.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+import { systemPrompt } from "@/lib/ai/prompts";
+
+const requestHints = {
+  latitude: 37.7749,
+  longitude: -122.4194,
+  city: "San Francisco",
+  country: "USA",
+};
+
+test.describe("system prompt persona", () => {
+  test("uses storytelling persona when project context is available", () => {
+    const prompt = systemPrompt({
+      selectedChatModel: "chat-model",
+      requestHints,
+      hasProjectContext: true,
+    });
+
+    expect(prompt).toContain("narrative-focused writing assistant");
+    expect(prompt).toContain("Project lore context is provided below");
+    expect(prompt).toContain("Artifacts is a special user interface mode");
+  });
+
+  test("keeps story persona for reasoning models without artifact guidance", () => {
+    const prompt = systemPrompt({
+      selectedChatModel: "chat-model-reasoning",
+      requestHints,
+      usesStoryTools: true,
+    });
+
+    expect(prompt).toContain("narrative-focused writing assistant");
+    expect(prompt).toContain("When lore context is provided");
+    expect(prompt).not.toContain("Artifacts is a special user interface mode");
+  });
+});


### PR DESCRIPTION
## Summary
- add a storytelling-focused system prompt that highlights lore, continuity, and chapter planning
- propagate project/story flags into chat prompt generation so lore context availability is announced
- add prompt-level tests covering the storytelling persona output when a project is selected

## Testing
- pnpm exec playwright test tests/prompts/system-prompt.test.ts *(fails: Playwright web server from config did not start in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693448adfc4083258c64b949f1288f5b)