### PR TITLE
Add project-scoped source material uploads

### DIFF
--- a/app/(chat)/api/files/upload/route.ts
+++ b/app/(chat)/api/files/upload/route.ts
@@ -1,68 +1,202 @@
+import { Buffer } from "node:buffer";
+
 import { put } from "@vercel/blob";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
 import { auth } from "@/app/(auth)/auth";
+import { getProjectByIdWithAccess } from "@/lib/db/queries";
+import {
+  createPendingSourceMaterial,
+  formatBytes,
+  getSourceMaterialUploadKey,
+  markSourceMaterialAsFailed,
+  markSourceMaterialAsUploaded,
+  sanitizeSourceMaterialName,
+  serializeSourceMaterial,
+  sourceMaterialSizeLimits,
+  supportedSourceMaterialMimeTypes,
+} from "@/lib/source-materials";
 
-// Use Blob instead of File since File is not available in Node.js environment
-const FileSchema = z.object({
-  file: z
-    .instanceof(Blob)
-    .refine((file) => file.size <= 5 * 1024 * 1024, {
-      message: "File size should be less than 5MB",
-    })
-    // Update the file type based on the kind of files you want to accept
-    .refine((file) => ["image/jpeg", "image/png"].includes(file.type), {
-      message: "File type should be JPEG or PNG",
-    }),
+const uploadSchema = z.object({
+  projectId: z.string().uuid(),
 });
+
+type UploadErrorCode =
+  | "unauthorized:upload"
+  | "invalid_payload:upload"
+  | "missing_project:upload"
+  | "invalid_type:upload"
+  | "too_large:upload"
+  | "server_error:upload";
+
+const uploadErrorResponses: Record<
+  UploadErrorCode,
+  { message: string; status: number }
+> = {
+  "unauthorized:upload": {
+    message: "You must be signed in to upload files.",
+    status: 401,
+  },
+  "invalid_payload:upload": {
+    message: "A valid file upload payload is required.",
+    status: 400,
+  },
+  "missing_project:upload": {
+    message: "Uploads must be associated with a valid project.",
+    status: 403,
+  },
+  "invalid_type:upload": {
+    message: "Unsupported file type. Upload a PDF, EPUB, DOCX, or TXT file.",
+    status: 400,
+  },
+  "too_large:upload": {
+    message: "File exceeds the maximum allowed size for your account.",
+    status: 400,
+  },
+  "server_error:upload": {
+    message: "Upload failed. Please try again.",
+    status: 500,
+  },
+};
+
+function errorResponse(
+  code: UploadErrorCode,
+  messageOverride?: string,
+  statusOverride?: number
+) {
+  const base = uploadErrorResponses[code];
+  return NextResponse.json(
+    {
+      code,
+      status: "error",
+      message: messageOverride ?? base.message,
+    },
+    { status: statusOverride ?? base.status }
+  );
+}
 
 export async function POST(request: Request) {
   const session = await auth();
 
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session?.user) {
+    return errorResponse("unauthorized:upload");
   }
 
-  if (request.body === null) {
-    return new Response("Request body is empty", { status: 400 });
+  if (!request.body) {
+    return errorResponse("invalid_payload:upload", "Request body is empty.");
   }
+
+  const formData = await request.formData().catch(() => null);
+
+  if (!formData) {
+    return errorResponse(
+      "invalid_payload:upload",
+      "Unable to parse the provided form data."
+    );
+  }
+
+  const fileEntry = formData.get("file");
+  const projectIdValue = formData.get("projectId");
+
+  if (!(fileEntry instanceof File)) {
+    return errorResponse("invalid_payload:upload", "A file must be provided.");
+  }
+
+  const parsedProjectId = uploadSchema.safeParse({ projectId: projectIdValue });
+
+  if (!parsedProjectId.success) {
+    return errorResponse(
+      "missing_project:upload",
+      "A valid projectId is required before uploading files."
+    );
+  }
+
+  const projectId = parsedProjectId.data.projectId;
+
+  const project = await getProjectByIdWithAccess({
+    id: projectId,
+    userId: session.user.id,
+  });
+
+  if (!project) {
+    return errorResponse(
+      "missing_project:upload",
+      "Project not found or unavailable.",
+      403
+    );
+  }
+
+  const mimeType = fileEntry.type.toLowerCase();
+
+  if (!supportedSourceMaterialMimeTypes.has(mimeType)) {
+    return errorResponse("invalid_type:upload");
+  }
+
+  const sizeLimit =
+    sourceMaterialSizeLimits[session.user.type] ??
+    sourceMaterialSizeLimits.regular;
+
+  if (fileEntry.size > sizeLimit) {
+    return errorResponse(
+      "too_large:upload",
+      `File exceeds the ${formatBytes(sizeLimit)} limit for your account.`
+    );
+  }
+
+  const filename = sanitizeSourceMaterialName(fileEntry.name);
+
+  const pendingMaterial = await createPendingSourceMaterial({
+    filename,
+    mimeType,
+    projectId,
+    size: fileEntry.size,
+    userId: session.user.id,
+  });
+
+  const uploadKey = getSourceMaterialUploadKey(projectId, filename);
 
   try {
-    const formData = await request.formData();
-    const file = formData.get("file") as Blob;
+    const fileBuffer = Buffer.from(await fileEntry.arrayBuffer());
+    const blob = await put(uploadKey, fileBuffer, {
+      access: "public",
+      contentType: mimeType,
+    });
 
-    if (!file) {
-      return NextResponse.json({ error: "No file uploaded" }, { status: 400 });
+    const uploadedMaterial = await markSourceMaterialAsUploaded({
+      blobUrl: blob.url,
+      id: pendingMaterial.id,
+    });
+
+    if (!uploadedMaterial) {
+      await Promise.resolve(
+        markSourceMaterialAsFailed({ id: pendingMaterial.id })
+      ).catch(() => null);
+      return errorResponse(
+        "server_error:upload",
+        "Upload was stored but metadata could not be finalized."
+      );
     }
 
-    const validatedFile = FileSchema.safeParse({ file });
+    return NextResponse.json({
+      status: "uploaded",
+      previousStatus: pendingMaterial.status,
+      material: serializeSourceMaterial(uploadedMaterial),
+      blob: {
+        url: blob.url,
+        pathname: blob.pathname,
+        contentType: blob.contentType,
+        size: fileEntry.size,
+      },
+    });
+  } catch (error) {
+    await Promise.resolve(
+      markSourceMaterialAsFailed({ id: pendingMaterial.id })
+    ).catch(() => null);
 
-    if (!validatedFile.success) {
-      const errorMessage = validatedFile.error.errors
-        .map((error) => error.message)
-        .join(", ");
+    const message =
+      error instanceof Error ? error.message : uploadErrorResponses["server_error:upload"].message;
 
-      return NextResponse.json({ error: errorMessage }, { status: 400 });
-    }
-
-    // Get filename from formData since Blob doesn't have name property
-    const filename = (formData.get("file") as File).name;
-    const fileBuffer = await file.arrayBuffer();
-
-    try {
-      const data = await put(`${filename}`, fileBuffer, {
-        access: "public",
-      });
-
-      return NextResponse.json(data);
-    } catch (_error) {
-      return NextResponse.json({ error: "Upload failed" }, { status: 500 });
-    }
-  } catch (_error) {
-    return NextResponse.json(
-      { error: "Failed to process request" },
-      { status: 500 }
-    );
+    return errorResponse("server_error:upload", message);
   }
 }

--- a/components/artifact.tsx
+++ b/components/artifact.tsx
@@ -71,6 +71,7 @@ function PureArtifact({
   selectedVisibilityType,
   selectedModelId,
   availableModels,
+  projectId,
 }: {
   chatId: string;
   input: string;
@@ -88,6 +89,7 @@ function PureArtifact({
   selectedVisibilityType: VisibilityType;
   selectedModelId: ChatModelId;
   availableModels: ChatModel[];
+  projectId?: string | null;
 }) {
   const { artifact, setArtifact, metadata, setMetadata } = useArtifact();
 
@@ -355,6 +357,7 @@ function PureArtifact({
                     setMessages={setMessages}
                     status={status}
                     stop={stop}
+                    projectId={projectId}
                   />
                 </div>
               </div>
@@ -532,6 +535,9 @@ export const Artifact = memo(PureArtifact, (prevProps, nextProps) => {
     return false;
   }
   if (!equal(prevProps.messages, nextProps.messages.length)) {
+    return false;
+  }
+  if (prevProps.projectId !== nextProps.projectId) {
     return false;
   }
   if (prevProps.selectedVisibilityType !== nextProps.selectedVisibilityType) {

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -366,6 +366,7 @@ export function Chat({
                 setMessages={setMessages}
                 status={status}
                 stop={stop}
+                projectId={selectedProjectId}
                 usage={usage}
               />
             )}
@@ -383,6 +384,7 @@ export function Chat({
         regenerate={regenerate}
         selectedModelId={currentModelId}
         selectedVisibilityType={visibilityType}
+        projectId={selectedProjectId}
         sendMessage={sendMessage}
         setAttachments={setAttachments}
         setInput={setInput}

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -67,6 +67,7 @@ function PureMultimodalInput({
   onModelChange,
   usage,
   availableModels,
+  projectId,
 }: {
   chatId: string;
   input: string;
@@ -84,6 +85,7 @@ function PureMultimodalInput({
   onModelChange?: (modelId: ChatModelId) => void;
   usage?: AppUsage;
   availableModels: ChatModel[];
+  projectId?: string | null;
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { width } = useWindowSize();
@@ -173,32 +175,47 @@ function PureMultimodalInput({
     resetHeight,
   ]);
 
-  const uploadFile = useCallback(async (file: File) => {
-    const formData = new FormData();
-    formData.append("file", file);
-
-    try {
-      const response = await fetch("/api/files/upload", {
-        method: "POST",
-        body: formData,
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        const { url, pathname, contentType } = data;
-
-        return {
-          url,
-          name: pathname,
-          contentType,
-        };
+  const uploadFile = useCallback(
+    async (file: File) => {
+      if (!projectId) {
+        toast.error("Select a project before uploading files.");
+        return;
       }
-      const { error } = await response.json();
-      toast.error(error);
-    } catch (_error) {
-      toast.error("Failed to upload file, please try again!");
-    }
-  }, []);
+
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("projectId", projectId);
+
+      try {
+        const response = await fetch("/api/files/upload", {
+          method: "POST",
+          body: formData,
+        });
+
+        const payload = await response.json();
+
+        if (response.ok && payload.status === "uploaded") {
+          const material = payload.material;
+          const contentType = material?.mimeType ?? payload.blob?.contentType;
+          const url = material?.blobUrl ?? payload.blob?.url;
+
+          if (material && url) {
+            return {
+              url,
+              name: material.filename,
+              contentType: contentType ?? file.type,
+            };
+          }
+        }
+
+        const errorMessage = payload.message ?? "Failed to upload file.";
+        toast.error(errorMessage);
+      } catch (_error) {
+        toast.error("Failed to upload file, please try again!");
+      }
+    },
+    [projectId]
+  );
 
   const contextProps = useMemo(
     () => ({
@@ -421,6 +438,9 @@ export const MultimodalInput = memo(
       return false;
     }
     if (prevProps.selectedModelId !== nextProps.selectedModelId) {
+      return false;
+    }
+    if (prevProps.projectId !== nextProps.projectId) {
       return false;
     }
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -10,13 +10,14 @@ This document summarizes the key modules that power the chat experience, persist
 ## Data persistence
 - **Database access**: `lib/db/queries.ts` centralizes Drizzle ORM queries against Postgres for users, chats, messages, streams, votes, and documents. It handles lifecycle operations such as creating chats, saving or deleting messages, updating visibility, pagination for history, and persisting usage context for analytics and throttling.【F:lib/db/queries.ts†L1-L200】
 - **Schema coverage**: The same module offers helpers for counting messages per user (used in rate limits), saving stream IDs for resumable transport, pruning trailing messages, and recording votes or suggestions associated with chats.【F:lib/db/queries.ts†L200-L520】
+- **Source material ledger**: The `SourceMaterial` table records uploaded reference files with project and user links, MIME type, size, blob URL, and status transitions, indexed by project and user for quick retrieval during chat grounding.【F:lib/db/schema.ts†L67-L92】
 
 ## Authentication
 - **NextAuth configuration**: `app/(auth)/auth.ts` configures credential-based login and a guest-provider pathway. Sessions attach `id` and `type` to the JWT and session objects, allowing downstream handlers (such as `/api/chat` and file uploads) to authorize requests and apply entitlements based on user type.【F:app/(auth)/auth.ts†L1-L73】
 - **Auth gating**: The chat entry page enforces authentication by redirecting unauthenticated users through the guest sign-in route before instantiating a new chat session, ensuring every chat run is associated with a user identity.【F:app/(chat)/page.tsx†L16-L43】
 
 ## File/blob storage
-- **Uploads via Vercel Blob**: The `/api/files/upload` endpoint validates file uploads (type and 5 MB limit), requires an authenticated session, and writes blobs with public access using Vercel Blob’s `put` API. Errors are surfaced with descriptive responses for client handling.【F:app/(chat)/api/files/upload/route.ts†L1-L63】
+- **Uploads via Vercel Blob**: The `/api/files/upload` endpoint enforces project-scoped uploads (auth + projectId), validates PDF/EPUB/DOCX/TXT MIME types, and applies per-role size limits before creating a pending `SourceMaterial` record. After the blob is written with a project prefix, the handler advances the record to `uploaded` status and returns structured status and error codes for clients.【F:app/(chat)/api/files/upload/route.ts†L1-L158】【F:lib/source-materials.ts†L1-L88】
 
 ## AI SDK integration
 - **Provider registry**: `lib/ai/providers.ts` declares language model IDs via the AI SDK `customProvider`, defaulting to Vercel AI Gateway-backed xAI models in production and mocked models in tests. Reasoning models are wrapped with `extractReasoningMiddleware` to expose “think” traces alongside responses.【F:lib/ai/providers.ts†L1-L29】

--- a/lib/db/migrations/0012_source_materials.sql
+++ b/lib/db/migrations/0012_source_materials.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS "SourceMaterial" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    "createdAt" timestamp NOT NULL,
+    "updatedAt" timestamp NOT NULL,
+    "filename" text NOT NULL,
+    "mimeType" varchar(128) NOT NULL,
+    "size" integer NOT NULL,
+    "status" varchar DEFAULT 'pending' NOT NULL,
+    "blobUrl" text,
+    "projectId" uuid NOT NULL,
+    "userId" uuid NOT NULL,
+    CONSTRAINT "SourceMaterial_projectId_Project_id_fk" FOREIGN KEY ("projectId") REFERENCES "Project"("id"),
+    CONSTRAINT "SourceMaterial_userId_User_id_fk" FOREIGN KEY ("userId") REFERENCES "User"("id")
+);
+
+CREATE INDEX IF NOT EXISTS "source_material_project_idx" ON "SourceMaterial" ("projectId");
+CREATE INDEX IF NOT EXISTS "source_material_user_idx" ON "SourceMaterial" ("userId");

--- a/lib/db/migrations/meta/0012_snapshot.json
+++ b/lib/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1457 @@
+{
+  "id": "0ad1b09b-c06c-4976-b04e-d1c0f3a363a2",
+  "prevId": "3f9c7955-a6c9-4f88-8d17-d68b270c0ac1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "lastContext": {
+          "name": "lastContext",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": [
+            "id",
+            "createdAt"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Message_v2": {
+      "name": "Message_v2",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_v2_chatId_Chat_id_fk": {
+          "name": "Message_v2_chatId_Chat_id_fk",
+          "tableFrom": "Message_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Stream": {
+      "name": "Stream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Stream_chatId_Chat_id_fk": {
+          "name": "Stream_chatId_Chat_id_fk",
+          "tableFrom": "Stream",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Stream_id_pk": {
+          "name": "Stream_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_User_id_fk": {
+          "name": "Suggestion_userId_User_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "documentId",
+            "documentCreatedAt"
+          ],
+          "columnsTo": [
+            "id",
+            "createdAt"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Vote_v2": {
+      "name": "Vote_v2",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_v2_chatId_Chat_id_fk": {
+          "name": "Vote_v2_chatId_Chat_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_v2_messageId_Message_v2_id_fk": {
+          "name": "Vote_v2_messageId_Message_v2_id_fk",
+          "tableFrom": "Vote_v2",
+          "tableTo": "Message_v2",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_v2_chatId_messageId_pk": {
+          "name": "Vote_v2_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.Project": {
+      "name": "Project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "folders": {
+          "name": "folders",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Project_userId_User_id_fk": {
+          "name": "Project_userId_User_id_fk",
+          "tableFrom": "Project",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Entity": {
+      "name": "Entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entity_name_project_idx": {
+          "name": "entity_name_project_idx",
+          "columns": [
+            "projectId",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "Entity_projectId_Project_id_fk": {
+          "name": "Entity_projectId_Project_id_fk",
+          "tableFrom": "Entity",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.EntityAttribute": {
+      "name": "EntityAttribute",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataType": {
+          "name": "dataType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entity_attribute_name_idx": {
+          "name": "entity_attribute_name_idx",
+          "columns": [
+            "entityId",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "EntityAttribute_entityId_Entity_id_fk": {
+          "name": "EntityAttribute_entityId_Entity_id_fk",
+          "tableFrom": "EntityAttribute",
+          "tableTo": "Entity",
+          "columnsFrom": [
+            "entityId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "EntityAttribute_projectId_Project_id_fk": {
+          "name": "EntityAttribute_projectId_Project_id_fk",
+          "tableFrom": "EntityAttribute",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Relationship": {
+      "name": "Relationship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceEntityId": {
+          "name": "sourceEntityId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetEntityId": {
+          "name": "targetEntityId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "relationship_unique_idx": {
+          "name": "relationship_unique_idx",
+          "columns": [
+            "projectId",
+            "sourceEntityId",
+            "targetEntityId",
+            "type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "Relationship_projectId_Project_id_fk": {
+          "name": "Relationship_projectId_Project_id_fk",
+          "tableFrom": "Relationship",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Relationship_sourceEntityId_Entity_id_fk": {
+          "name": "Relationship_sourceEntityId_Entity_id_fk",
+          "tableFrom": "Relationship",
+          "tableTo": "Entity",
+          "columnsFrom": [
+            "sourceEntityId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Relationship_targetEntityId_Entity_id_fk": {
+          "name": "Relationship_targetEntityId_Entity_id_fk",
+          "tableFrom": "Relationship",
+          "tableTo": "Entity",
+          "columnsFrom": [
+            "targetEntityId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Outline": {
+      "name": "Outline",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pov": {
+          "name": "pov",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone": {
+          "name": "tone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pacing": {
+          "name": "pacing",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beats": {
+          "name": "beats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Outline_projectId_Project_id_fk": {
+          "name": "Outline_projectId_Project_id_fk",
+          "tableFrom": "Outline",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Volume": {
+      "name": "Volume",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outlineId": {
+          "name": "outlineId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Volume_outlineId_Outline_id_fk": {
+          "name": "Volume_outlineId_Outline_id_fk",
+          "tableFrom": "Volume",
+          "tableTo": "Outline",
+          "columnsFrom": [
+            "outlineId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Volume_projectId_Project_id_fk": {
+          "name": "Volume_projectId_Project_id_fk",
+          "tableFrom": "Volume",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.Chapter": {
+      "name": "Chapter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "planned"
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outlineId": {
+          "name": "outlineId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volumeId": {
+          "name": "volumeId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chapter_sequence_volume_idx": {
+          "name": "chapter_sequence_volume_idx",
+          "columns": [
+            "volumeId",
+            "sequence"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "Chapter_outlineId_Outline_id_fk": {
+          "name": "Chapter_outlineId_Outline_id_fk",
+          "tableFrom": "Chapter",
+          "tableTo": "Outline",
+          "columnsFrom": [
+            "outlineId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Chapter_volumeId_Volume_id_fk": {
+          "name": "Chapter_volumeId_Volume_id_fk",
+          "tableFrom": "Chapter",
+          "tableTo": "Volume",
+          "columnsFrom": [
+            "volumeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Chapter_projectId_Project_id_fk": {
+          "name": "Chapter_projectId_Project_id_fk",
+          "tableFrom": "Chapter",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.ChapterDraft": {
+      "name": "ChapterDraft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapterId": {
+          "name": "chapterId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volumeId": {
+          "name": "volumeId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outlineId": {
+          "name": "outlineId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ChapterDraft_chapterId_Chapter_id_fk": {
+          "name": "ChapterDraft_chapterId_Chapter_id_fk",
+          "tableFrom": "ChapterDraft",
+          "tableTo": "Chapter",
+          "columnsFrom": [
+            "chapterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ChapterDraft_volumeId_Volume_id_fk": {
+          "name": "ChapterDraft_volumeId_Volume_id_fk",
+          "tableFrom": "ChapterDraft",
+          "tableTo": "Volume",
+          "columnsFrom": [
+            "volumeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ChapterDraft_outlineId_Outline_id_fk": {
+          "name": "ChapterDraft_outlineId_Outline_id_fk",
+          "tableFrom": "ChapterDraft",
+          "tableTo": "Outline",
+          "columnsFrom": [
+            "outlineId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ChapterDraft_projectId_Project_id_fk": {
+          "name": "ChapterDraft_projectId_Project_id_fk",
+          "tableFrom": "ChapterDraft",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.SourceMaterial": {
+      "name": "SourceMaterial",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "size": 128
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "blobUrl": {
+          "name": "blobUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "source_material_project_idx": {
+          "name": "source_material_project_idx",
+          "columns": [
+            "projectId"
+          ],
+          "isUnique": false
+        },
+        "source_material_user_idx": {
+          "name": "source_material_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "SourceMaterial_projectId_Project_id_fk": {
+          "name": "SourceMaterial_projectId_Project_id_fk",
+          "tableFrom": "SourceMaterial",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "SourceMaterial_userId_User_id_fk": {
+          "name": "SourceMaterial_userId_User_id_fk",
+          "tableFrom": "SourceMaterial",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1764983916681,
       "tag": "0011_volume_chapters",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1765034721101,
+      "tag": "0012_source_materials",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -39,6 +39,9 @@ import {
   outline,
   type Project,
   project,
+  type SourceMaterial,
+  sourceMaterial,
+  type SourceMaterialStatus,
   type Relationship,
   relationship,
   type Suggestion,
@@ -1057,6 +1060,77 @@ export async function getProjectByIdWithAccess({
     throw new ChatSDKError(
       "bad_request:database",
       "Failed to load project by id"
+    );
+  }
+}
+
+export async function createSourceMaterial({
+  blobUrl,
+  filename,
+  mimeType,
+  projectId,
+  size,
+  status,
+  userId,
+}: {
+  blobUrl?: string | null;
+  filename: string;
+  mimeType: string;
+  projectId: string;
+  size: number;
+  status: SourceMaterialStatus;
+  userId: string;
+}): Promise<SourceMaterial> {
+  try {
+    const [material] = await db
+      .insert(sourceMaterial)
+      .values({
+        blobUrl,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        filename,
+        mimeType,
+        projectId,
+        size,
+        status,
+        userId,
+      })
+      .returning();
+
+    return material;
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to create source material record"
+    );
+  }
+}
+
+export async function updateSourceMaterial({
+  blobUrl,
+  id,
+  status,
+}: {
+  blobUrl?: string | null;
+  id: string;
+  status: SourceMaterialStatus;
+}): Promise<SourceMaterial | null> {
+  try {
+    const [material] = await db
+      .update(sourceMaterial)
+      .set({
+        blobUrl,
+        status,
+        updatedAt: new Date(),
+      })
+      .where(eq(sourceMaterial.id, id))
+      .returning();
+
+    return material ?? null;
+  } catch (_error) {
+    throw new ChatSDKError(
+      "bad_request:database",
+      "Failed to update source material record"
     );
   }
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -2,6 +2,7 @@ import type { InferSelectModel } from "drizzle-orm";
 import {
   boolean,
   foreignKey,
+  index,
   integer,
   json,
   jsonb,
@@ -114,6 +115,9 @@ export type ProjectFolder = {
   description: string;
 };
 
+export const sourceMaterialStatus = ["pending", "uploaded", "failed"] as const;
+export type SourceMaterialStatus = (typeof sourceMaterialStatus)[number];
+
 export const project = pgTable("Project", {
   id: uuid("id").primaryKey().notNull().defaultRandom(),
   createdAt: timestamp("createdAt").notNull(),
@@ -129,6 +133,34 @@ export const project = pgTable("Project", {
 });
 
 export type Project = InferSelectModel<typeof project>;
+
+export const sourceMaterial = pgTable(
+  "SourceMaterial",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    createdAt: timestamp("createdAt").notNull(),
+    updatedAt: timestamp("updatedAt").notNull(),
+    filename: text("filename").notNull(),
+    mimeType: varchar("mimeType", { length: 128 }).notNull(),
+    size: integer("size").notNull(),
+    status: varchar("status", { enum: sourceMaterialStatus })
+      .notNull()
+      .default("pending"),
+    blobUrl: text("blobUrl"),
+    projectId: uuid("projectId")
+      .notNull()
+      .references(() => project.id),
+    userId: uuid("userId")
+      .notNull()
+      .references(() => user.id),
+  },
+  (table) => ({
+    projectIdx: index("source_material_project_idx").on(table.projectId),
+    userIdx: index("source_material_user_idx").on(table.userId),
+  })
+);
+
+export type SourceMaterial = InferSelectModel<typeof sourceMaterial>;
 
 export const entity = pgTable(
   "Entity",

--- a/lib/source-materials.ts
+++ b/lib/source-materials.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from "node:crypto";
+
+import type { UserType } from "@/app/(auth)/auth";
+import { createSourceMaterial, updateSourceMaterial } from "@/lib/db/queries";
+import type { SourceMaterial } from "@/lib/db/schema";
+
+export const supportedSourceMaterialMimeTypes = new Set<string>([
+  "application/pdf",
+  "application/epub+zip",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "text/plain",
+]);
+
+export const sourceMaterialSizeLimits: Record<UserType, number> = {
+  guest: 5 * 1024 * 1024,
+  regular: 20 * 1024 * 1024,
+};
+
+export type SerializedSourceMaterial = Omit<SourceMaterial, "createdAt" | "updatedAt"> & {
+  createdAt: string;
+  updatedAt: string;
+};
+
+export function isSupportedSourceMaterialType(mimeType: string): boolean {
+  return supportedSourceMaterialMimeTypes.has(mimeType.toLowerCase());
+}
+
+export function sanitizeSourceMaterialName(filename: string): string {
+  const trimmed = filename.trim();
+  const safeName = trimmed.replace(/[^a-zA-Z0-9._-]+/g, "_");
+  return safeName.length > 0 ? safeName : `upload-${randomUUID()}`;
+}
+
+export function getSourceMaterialUploadKey(
+  projectId: string,
+  filename: string
+): string {
+  const timestamp = Date.now();
+  const safeName = sanitizeSourceMaterialName(filename);
+  return `projects/${projectId}/${timestamp}-${safeName}`;
+}
+
+export function serializeSourceMaterial(
+  material: SourceMaterial
+): SerializedSourceMaterial {
+  return {
+    ...material,
+    createdAt: material.createdAt.toISOString(),
+    updatedAt: material.updatedAt.toISOString(),
+  };
+}
+
+export async function createPendingSourceMaterial({
+  filename,
+  mimeType,
+  projectId,
+  size,
+  userId,
+}: {
+  filename: string;
+  mimeType: string;
+  projectId: string;
+  size: number;
+  userId: string;
+}): Promise<SourceMaterial> {
+  return createSourceMaterial({
+    filename,
+    mimeType,
+    projectId,
+    size,
+    status: "pending",
+    userId,
+  });
+}
+
+export async function markSourceMaterialAsUploaded({
+  blobUrl,
+  id,
+}: {
+  blobUrl: string;
+  id: string;
+}): Promise<SourceMaterial | null> {
+  return updateSourceMaterial({
+    blobUrl,
+    id,
+    status: "uploaded",
+  });
+}
+
+export async function markSourceMaterialAsFailed({
+  id,
+}: {
+  id: string;
+}): Promise<SourceMaterial | null> {
+  return updateSourceMaterial({
+    blobUrl: null,
+    id,
+    status: "failed",
+  });
+}
+
+export function formatBytes(bytes: number): string {
+  const megabytes = bytes / (1024 * 1024);
+  return `${megabytes.toFixed(1)}MB`;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     "tailwindcss": "^4.1.13",
     "tsx": "^4.19.1",
     "typescript": "^5.6.3",
-    "ultracite": "5.3.9"
+    "ultracite": "5.3.9",
+    "vitest": "^3.2.4"
   },
   "packageManager": "pnpm@9.12.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       ultracite:
         specifier: 5.3.9
         version: 5.3.9(@types/debug@4.1.12)(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.19.3)(yaml@2.7.0)
 
 packages:
 
@@ -3690,10 +3693,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
@@ -6935,7 +6934,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
 
   eventsource-parser@3.0.6: {}
 
@@ -7686,7 +7685,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.0
+      debug: 4.4.3
       decode-named-character-reference: 1.1.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -7846,8 +7845,6 @@ snapshots:
     optional: true
 
   picocolors@1.1.1: {}
-
-  picomatch@4.0.2: {}
 
   picomatch@4.0.3: {}
 
@@ -8706,7 +8703,7 @@ snapshots:
       expect-type: 1.2.2
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.2
+      picomatch: 4.0.3
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2

--- a/tests/unit/api/files-upload.test.ts
+++ b/tests/unit/api/files-upload.test.ts
@@ -1,0 +1,254 @@
+import { Buffer } from "node:buffer";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/(auth)/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/db/queries", () => ({
+  getProjectByIdWithAccess: vi.fn(),
+}));
+
+vi.mock("@/lib/source-materials", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/source-materials")>();
+
+  return {
+    ...actual,
+    createPendingSourceMaterial: vi.fn(),
+    markSourceMaterialAsUploaded: vi.fn(),
+    markSourceMaterialAsFailed: vi.fn(),
+  };
+});
+
+vi.mock("@vercel/blob", () => ({
+  put: vi.fn(),
+}));
+
+import { auth } from "@/app/(auth)/auth";
+import { POST } from "@/app/(chat)/api/files/upload/route";
+import { getProjectByIdWithAccess } from "@/lib/db/queries";
+import {
+  createPendingSourceMaterial,
+  markSourceMaterialAsFailed,
+  markSourceMaterialAsUploaded,
+  sourceMaterialSizeLimits,
+} from "@/lib/source-materials";
+import type { Project, SourceMaterial } from "@/lib/db/schema";
+import { put } from "@vercel/blob";
+import type { Session } from "next-auth";
+
+const mockedAuth = vi.mocked(auth);
+const mockedGetProjectByIdWithAccess = vi.mocked(getProjectByIdWithAccess);
+const mockedCreatePendingSourceMaterial = vi.mocked(createPendingSourceMaterial);
+const mockedMarkSourceMaterialAsUploaded = vi.mocked(markSourceMaterialAsUploaded);
+const mockedMarkSourceMaterialAsFailed = vi.mocked(markSourceMaterialAsFailed);
+const mockedPut = vi.mocked(put);
+const projectId = "11111111-1111-1111-1111-111111111111";
+
+function buildSession(userId: string, type: "guest" | "regular"): Session {
+  return {
+    user: {
+      email: null,
+      id: userId,
+      image: null,
+      name: null,
+      type,
+    },
+    expires: new Date().toISOString(),
+  };
+}
+
+function buildProject(projectId: string, userId: string): Project {
+  return {
+    createdAt: new Date(),
+    description: null,
+    folders: [],
+    id: projectId,
+    name: "Test Project",
+    userId,
+    visibility: "private",
+  };
+}
+
+function buildRequest({
+  file,
+  projectId,
+}: {
+  file: File;
+  projectId: string;
+}) {
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("projectId", projectId);
+
+  return new Request("http://localhost/api/files/upload", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+describe("POST /api/files/upload", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("persists a supported file type and returns the uploaded material", async () => {
+    const file = new File(["hello"], "story.pdf", { type: "application/pdf" });
+    const pendingMaterial: SourceMaterial = {
+      id: "mat-1",
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      updatedAt: new Date("2024-01-01T00:00:00Z"),
+      filename: file.name,
+      mimeType: file.type,
+      projectId,
+      size: file.size,
+      status: "pending",
+      userId: "user-1",
+      blobUrl: null,
+    };
+
+    mockedAuth.mockResolvedValue(buildSession("user-1", "regular"));
+    mockedGetProjectByIdWithAccess.mockResolvedValue(
+      buildProject(projectId, "user-1")
+    );
+    mockedCreatePendingSourceMaterial.mockResolvedValue(pendingMaterial);
+    mockedPut.mockResolvedValue({
+      url: `https://blob.vercel.store/projects/${projectId}/story.pdf`,
+      pathname: `projects/${projectId}/story.pdf`,
+      contentType: file.type,
+    } as any);
+    mockedMarkSourceMaterialAsUploaded.mockResolvedValue({
+      ...pendingMaterial,
+      status: "uploaded",
+      blobUrl: `https://blob.vercel.store/projects/${projectId}/story.pdf`,
+      updatedAt: new Date("2024-01-02T00:00:00Z"),
+    });
+
+    const response = await POST(
+      buildRequest({ file, projectId: pendingMaterial.projectId })
+    );
+
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.status).toBe("uploaded");
+    expect(payload.previousStatus).toBe("pending");
+    expect(payload.material.blobUrl).toContain("story.pdf");
+    expect(mockedPut).toHaveBeenCalledWith(
+      expect.stringContaining(`projects/${pendingMaterial.projectId}`),
+      expect.any(Buffer),
+      expect.objectContaining({ contentType: file.type })
+    );
+    expect(mockedMarkSourceMaterialAsUploaded).toHaveBeenCalledWith({
+      blobUrl: expect.stringContaining("story.pdf"),
+      id: pendingMaterial.id,
+    });
+  });
+
+  it("rejects unsupported MIME types", async () => {
+    const file = new File(["bad"], "image.gif", { type: "image/gif" });
+
+    mockedAuth.mockResolvedValue(buildSession("user-1", "regular"));
+    mockedGetProjectByIdWithAccess.mockResolvedValue(
+      buildProject(projectId, "user-1")
+    );
+
+    const response = await POST(
+      buildRequest({ file, projectId })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.code).toBe("invalid_type:upload");
+    expect(mockedCreatePendingSourceMaterial).not.toHaveBeenCalled();
+    expect(mockedPut).not.toHaveBeenCalled();
+  });
+
+  it("enforces per-role size caps", async () => {
+    const sizeLimit = sourceMaterialSizeLimits.guest;
+    const file = new File([new Uint8Array(sizeLimit + 1)], "oversize.pdf", {
+      type: "application/pdf",
+    });
+
+    mockedAuth.mockResolvedValue(buildSession("guest-1", "guest"));
+    mockedGetProjectByIdWithAccess.mockResolvedValue(
+      buildProject(projectId, "guest-1")
+    );
+
+    const response = await POST(
+      buildRequest({ file, projectId })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.code).toBe("too_large:upload");
+    expect(mockedCreatePendingSourceMaterial).not.toHaveBeenCalled();
+    expect(mockedPut).not.toHaveBeenCalled();
+  });
+
+  it("requires an authenticated session", async () => {
+    const file = new File(["hello"], "story.pdf", { type: "application/pdf" });
+
+    mockedAuth.mockResolvedValue(null);
+
+    const response = await POST(
+      buildRequest({ file, projectId })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.code).toBe("unauthorized:upload");
+    expect(mockedGetProjectByIdWithAccess).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the project cannot be found", async () => {
+    const file = new File(["hello"], "story.pdf", { type: "application/pdf" });
+
+    mockedAuth.mockResolvedValue(buildSession("user-1", "regular"));
+    mockedGetProjectByIdWithAccess.mockResolvedValue(null);
+
+    const response = await POST(
+      buildRequest({ file, projectId })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(payload.code).toBe("missing_project:upload");
+    expect(mockedCreatePendingSourceMaterial).not.toHaveBeenCalled();
+  });
+
+  it("marks a pending material as failed when blob persistence errors", async () => {
+    const file = new File(["hello"], "story.pdf", { type: "application/pdf" });
+    const pendingMaterial: SourceMaterial = {
+      id: "mat-err",
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      updatedAt: new Date("2024-01-01T00:00:00Z"),
+      filename: file.name,
+      mimeType: file.type,
+      projectId,
+      size: file.size,
+      status: "pending",
+      userId: "user-1",
+      blobUrl: null,
+    };
+
+    mockedAuth.mockResolvedValue(buildSession("user-1", "regular"));
+    mockedGetProjectByIdWithAccess.mockResolvedValue(
+      buildProject(projectId, "user-1")
+    );
+    mockedCreatePendingSourceMaterial.mockResolvedValue(pendingMaterial);
+    mockedPut.mockRejectedValue(new Error("blob failed"));
+
+    const response = await POST(
+      buildRequest({ file, projectId: pendingMaterial.projectId })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload.code).toBe("server_error:upload");
+    expect(mockedMarkSourceMaterialAsFailed).toHaveBeenCalledWith({
+      id: pendingMaterial.id,
+    });
+  });
+});

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -1,0 +1,1 @@
+process.env.NEXT_RUNTIME = process.env.NEXT_RUNTIME ?? "nodejs";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: ["./tests/vitest.setup.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add SourceMaterial schema, queries, and helper utilities for project-scoped uploads
- enforce authenticated project uploads with MIME/type limits, size caps, and statusful responses
- wire projectId through upload UI and add unit tests for allowed/blocked uploads and failure handling

## Testing
- pnpm exec vitest run tests/unit/api/files-upload.test.ts
- pnpm test (fails: Playwright web server did not start)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693448b450e083258d06af5f1207d41b)