### PR TITLE
Enforce access control for entity actions

### DIFF
--- a/app/actions/entities.ts
+++ b/app/actions/entities.ts
@@ -1,84 +1,122 @@
 "use server";
 
 import { auth } from "@/app/(auth)/auth";
-import { getEntitiesForProject, updateEntity } from "@/lib/db/queries";
+import {
+        deleteEntity,
+        getEntitiesForProject,
+        getEntityById,
+        getProjectByIdWithAccess,
+        updateEntity,
+} from "@/lib/db/queries";
+import { revalidatePath } from "next/cache";
 
 export async function getEntities(projectId: string) {
-	const session = await auth();
+        const session = await auth();
 
-	if (!session) {
-		throw new Error("Unauthorized");
-	}
+        if (!session?.user?.id) {
+                throw new Error("Unauthorized");
+        }
 
-	// TODO: Verify user access to the project if needed,
-	// though getEntitiesForProject might just return empty if ID is invalid
-	// or we rely on the UI to not pass invalid IDs.
-	// ideally getProjectByIdWithAccess check should be here or in the query.
+        const project = await getProjectByIdWithAccess({
+                id: projectId,
+                userId: session.user.id,
+        });
 
-	const entities = await getEntitiesForProject({ projectId });
+        if (!project) {
+                throw new Error("Project not found or access denied");
+        }
 
-	// Serialize dates
-	return entities.map((entity) => ({
-		...entity,
-		createdAt: entity.createdAt.toISOString(),
-		updatedAt: entity.updatedAt.toISOString(),
-		startDate: entity.startDate?.toISOString() ?? null,
-		endDate: entity.endDate?.toISOString() ?? null,
-	}));
+        const entities = await getEntitiesForProject({ projectId });
+
+        // Serialize dates
+        return entities.map((entity) => ({
+                ...entity,
+                createdAt: entity.createdAt.toISOString(),
+                updatedAt: entity.updatedAt.toISOString(),
+                startDate: entity.startDate?.toISOString() ?? null,
+                endDate: entity.endDate?.toISOString() ?? null,
+        }));
 }
 
 export async function updateEntityAction({
-	id,
-	name,
-	kind,
-	summary,
-	attributes,
-	projectId,
+        id,
+        name,
+        kind,
+        summary,
+        attributes,
+        projectId,
 }: {
-	id: string;
-	name?: string;
-	kind?: string;
-	summary?: string;
-	attributes?: Array<{ name: string; value: string }>;
-	projectId: string;
+        id: string;
+        name?: string;
+        kind?: string;
+        summary?: string;
+        attributes?: Array<{ name: string; value: string }>;
+        projectId: string;
 }) {
-	const session = await auth();
+        const session = await auth();
 
-	if (!session) {
-		throw new Error("Unauthorized");
-	}
+        if (!session?.user?.id) {
+                throw new Error("Unauthorized");
+        }
 
-	// TODO: Verify access to project
+        const entity = await getEntityById({ id });
 
-	const updatedEntity = await updateEntity({
-		id,
-		name,
-		kind,
-		summary,
-		attributes,
-	});
+        if (!entity) {
+                throw new Error("Entity not found");
+        }
 
-	return {
-		...updatedEntity,
-		createdAt: updatedEntity.createdAt.toISOString(),
-		updatedAt: updatedEntity.updatedAt.toISOString(),
-		startDate: updatedEntity.startDate?.toISOString() ?? null,
-		endDate: updatedEntity.endDate?.toISOString() ?? null,
-	};
+        const project = await getProjectByIdWithAccess({
+                id: entity.projectId,
+                userId: session.user.id,
+        });
+
+        if (!project) {
+                throw new Error("Access denied to entity");
+        }
+
+        if (entity.projectId !== projectId) {
+                throw new Error("Entity does not belong to the provided project");
+        }
+
+        const updatedEntity = await updateEntity({
+                id,
+                name,
+                kind,
+                summary,
+                attributes,
+        });
+
+        return {
+                ...updatedEntity,
+                createdAt: updatedEntity.createdAt.toISOString(),
+                updatedAt: updatedEntity.updatedAt.toISOString(),
+                startDate: updatedEntity.startDate?.toISOString() ?? null,
+                endDate: updatedEntity.endDate?.toISOString() ?? null,
+        };
 }
 
-import { revalidatePath } from "next/cache";
-import { deleteEntity } from "@/lib/db/queries";
-
 export async function deleteEntityAction(id: string) {
-	const session = await auth();
+        const session = await auth();
 
-	if (!session) {
-		throw new Error("Unauthorized");
-	}
+        if (!session?.user?.id) {
+                throw new Error("Unauthorized");
+        }
 
-	// TODO: Verify access to project
+        const entity = await getEntityById({ id });
 
-	await deleteEntity({ id });
-	revalidatePath("/(chat)", "page"); // Revalidate broadly to ensure lists update
+        if (!entity) {
+                throw new Error("Entity not found");
+        }
+
+        const project = await getProjectByIdWithAccess({
+                id: entity.projectId,
+                userId: session.user.id,
+        });
+
+        if (!project) {
+                throw new Error("Access denied to entity");
+        }
+
+        await deleteEntity({ id });
+        revalidatePath("/(chat)", "page"); // Revalidate broadly to ensure lists update
 }

--- a/tests/unit/actions/entities.test.ts
+++ b/tests/unit/actions/entities.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/(auth)/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/db/queries", () => ({
+  deleteEntity: vi.fn(),
+  getEntitiesForProject: vi.fn(),
+  getEntityById: vi.fn(),
+  getProjectByIdWithAccess: vi.fn(),
+  updateEntity: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { deleteEntityAction, getEntities, updateEntityAction } from "@/app/actions/entities";
+import { auth } from "@/app/(auth)/auth";
+import {
+  deleteEntity,
+  getEntitiesForProject,
+  getEntityById,
+  getProjectByIdWithAccess,
+  updateEntity,
+} from "@/lib/db/queries";
+import type { Entity, Project } from "@/lib/db/schema";
+import { revalidatePath } from "next/cache";
+
+const mockedAuth = vi.mocked(auth);
+const mockedGetProjectByIdWithAccess = vi.mocked(getProjectByIdWithAccess);
+const mockedGetEntitiesForProject = vi.mocked(getEntitiesForProject);
+const mockedGetEntityById = vi.mocked(getEntityById);
+const mockedUpdateEntity = vi.mocked(updateEntity);
+const mockedDeleteEntity = vi.mocked(deleteEntity);
+const mockedRevalidatePath = vi.mocked(revalidatePath);
+
+const userId = "user-123";
+const projectId = "project-123";
+
+function buildSession() {
+  return {
+    user: {
+      email: null,
+      id: userId,
+      image: null,
+      name: "Test User",
+      type: "regular",
+    },
+    expires: new Date().toISOString(),
+  } as any;
+}
+
+function buildProject(overrides?: Partial<Project>): Project {
+  return {
+    id: projectId,
+    name: "Test Project",
+    description: null,
+    userId,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    visibility: "private",
+    folders: [],
+    ...overrides,
+  } as Project;
+}
+
+function buildEntity(overrides?: Partial<Entity>): Entity {
+  return {
+    id: "entity-123",
+    name: "Entity Name",
+    kind: "character",
+    summary: null,
+    projectId,
+    startDate: new Date("2024-01-02T00:00:00Z"),
+    endDate: null,
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+    updatedAt: new Date("2024-01-03T00:00:00Z"),
+    ...overrides,
+  } as Entity;
+}
+
+describe("entities server actions", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns entities when the user can access the project", async () => {
+    const entity = buildEntity();
+
+    mockedAuth.mockResolvedValue(buildSession());
+    mockedGetProjectByIdWithAccess.mockResolvedValue(buildProject());
+    mockedGetEntitiesForProject.mockResolvedValue([entity]);
+
+    const result = await getEntities(projectId);
+
+    expect(mockedGetProjectByIdWithAccess).toHaveBeenCalledWith({
+      id: projectId,
+      userId,
+    });
+    expect(result).toEqual([
+      {
+        ...entity,
+        createdAt: entity.createdAt.toISOString(),
+        updatedAt: entity.updatedAt.toISOString(),
+        startDate: entity.startDate?.toISOString(),
+        endDate: null,
+      },
+    ]);
+  });
+
+  it("throws when the project is inaccessible", async () => {
+    mockedAuth.mockResolvedValue(buildSession());
+    mockedGetProjectByIdWithAccess.mockResolvedValue(null);
+
+    await expect(getEntities(projectId)).rejects.toThrow(
+      "Project not found or access denied",
+    );
+    expect(mockedGetEntitiesForProject).not.toHaveBeenCalled();
+  });
+
+  it("updates an entity when the user owns the project", async () => {
+    const entity = buildEntity();
+    const updatedEntity = buildEntity({ name: "Updated" });
+
+    mockedAuth.mockResolvedValue(buildSession());
+    mockedGetEntityById.mockResolvedValue(entity);
+    mockedGetProjectByIdWithAccess.mockResolvedValue(buildProject());
+    mockedUpdateEntity.mockResolvedValue(updatedEntity);
+
+    const result = await updateEntityAction({
+      id: entity.id,
+      name: updatedEntity.name,
+      projectId,
+    });
+
+    expect(mockedGetProjectByIdWithAccess).toHaveBeenCalledWith({
+      id: projectId,
+      userId,
+    });
+    expect(mockedUpdateEntity).toHaveBeenCalledWith({
+      id: entity.id,
+      name: updatedEntity.name,
+      kind: undefined,
+      summary: undefined,
+      attributes: undefined,
+    });
+    expect(result.name).toBe(updatedEntity.name);
+    expect(result.updatedAt).toBe(updatedEntity.updatedAt.toISOString());
+  });
+
+  it("rejects updates when the user lacks access", async () => {
+    const entity = buildEntity();
+
+    mockedAuth.mockResolvedValue(buildSession());
+    mockedGetEntityById.mockResolvedValue(entity);
+    mockedGetProjectByIdWithAccess.mockResolvedValue(null);
+
+    await expect(
+      updateEntityAction({ id: entity.id, projectId }),
+    ).rejects.toThrow("Access denied to entity");
+    expect(mockedUpdateEntity).not.toHaveBeenCalled();
+  });
+
+  it("rejects updates when the entity belongs to another project", async () => {
+    const entity = buildEntity({ projectId: "other-project" });
+
+    mockedAuth.mockResolvedValue(buildSession());
+    mockedGetEntityById.mockResolvedValue(entity);
+    mockedGetProjectByIdWithAccess.mockResolvedValue(
+      buildProject({ id: entity.projectId }),
+    );
+
+    await expect(
+      updateEntityAction({ id: entity.id, projectId }),
+    ).rejects.toThrow("Entity does not belong to the provided project");
+    expect(mockedUpdateEntity).not.toHaveBeenCalled();
+  });
+
+  it("deletes an entity when the user has permission", async () => {
+    const entity = buildEntity();
+
+    mockedAuth.mockResolvedValue(buildSession());
+    mockedGetEntityById.mockResolvedValue(entity);
+    mockedGetProjectByIdWithAccess.mockResolvedValue(buildProject());
+    mockedDeleteEntity.mockResolvedValue();
+
+    await deleteEntityAction(entity.id);
+
+    expect(mockedDeleteEntity).toHaveBeenCalledWith({ id: entity.id });
+    expect(mockedRevalidatePath).toHaveBeenCalledWith("/(chat)", "page");
+  });
+
+  it("fails deletion when the user cannot access the project", async () => {
+    const entity = buildEntity();
+
+    mockedAuth.mockResolvedValue(buildSession());
+    mockedGetEntityById.mockResolvedValue(entity);
+    mockedGetProjectByIdWithAccess.mockResolvedValue(null);
+
+    await expect(deleteEntityAction(entity.id)).rejects.toThrow(
+      "Access denied to entity",
+    );
+    expect(mockedDeleteEntity).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add project ownership checks before listing, updating, or deleting entities
- validate entity ownership and surface explicit authorization errors
- add unit coverage for allowed and denied entity access scenarios

## Testing
- pnpm test *(fails: Playwright browsers not installed in environment)*
- CI=true pnpm exec vitest tests/unit/actions/entities.test.ts --watch=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c25235ff08325878685529267bd8d)