### PR TITLE
Refactor ingestion worker and extraction modules

### DIFF
--- a/lib/ingestion/backoff.ts
+++ b/lib/ingestion/backoff.ts
@@ -1,0 +1,38 @@
+import type { SourceMaterial } from "@/lib/db/schema";
+
+export const DEFAULT_BASE_BACKOFF_MS = 1000;
+export const DEFAULT_MAX_ATTEMPTS = 3;
+
+export type BackoffConfig = {
+  baseDelayMs?: number;
+  maxAttempts?: number;
+};
+
+export type BackoffResult = {
+  nextAttempts: number;
+  nextAttemptAt: Date;
+  status: SourceMaterial["status"];
+};
+
+export function calculateBackoff({
+  attempts,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  baseDelayMs = DEFAULT_BASE_BACKOFF_MS,
+}: {
+  attempts: number;
+  maxAttempts?: number;
+  baseDelayMs?: number;
+}): BackoffResult {
+  const nextAttempts = attempts + 1;
+  const shouldFail = nextAttempts >= maxAttempts;
+  const delayMs = baseDelayMs * 2 ** attempts;
+  const nextAttemptAt = shouldFail
+    ? new Date()
+    : new Date(Date.now() + delayMs);
+
+  return {
+    nextAttempts,
+    nextAttemptAt,
+    status: shouldFail ? "failed" : "uploaded",
+  };
+}

--- a/lib/ingestion/chunking.ts
+++ b/lib/ingestion/chunking.ts
@@ -1,0 +1,98 @@
+import type { NewSourceMaterialChapter, NewSourceMaterialChunk } from "@/lib/db/schema";
+import { generateUUID } from "@/lib/utils";
+
+import type { ExtractedContent, NormalizedExtraction } from "./types";
+import { deriveHeadings, normalizeTextContent } from "./text";
+
+export const DEFAULT_CHUNK_SIZE = 1200;
+
+export function splitIntoChunks(text: string, chunkSize: number): string[] {
+  if (!text) return [];
+
+  const normalized = normalizeTextContent(text);
+  const parts: string[] = [];
+  let cursor = 0;
+
+  while (cursor < normalized.length) {
+    const slice = normalized.slice(cursor, cursor + chunkSize);
+    const lastSpace = slice.lastIndexOf(" ");
+    const end = lastSpace > 0 ? cursor + lastSpace : cursor + slice.length;
+    parts.push(normalized.slice(cursor, end).trim());
+    cursor = end;
+  }
+
+  return parts.filter(Boolean);
+}
+
+export function buildChaptersAndChunks({
+  text,
+  headings,
+  chunkSize,
+}: {
+  text: string;
+  headings: string[];
+  chunkSize: number;
+}): { chapters: NewSourceMaterialChapter[]; chunks: NewSourceMaterialChunk[] } {
+  const normalized = normalizeTextContent(text);
+
+  if (!normalized) {
+    return { chapters: [], chunks: [] };
+  }
+
+  const derivedHeadings = headings.length > 0 ? headings : deriveHeadings(normalized);
+
+  const chapters: NewSourceMaterialChapter[] = [];
+  const chunks: NewSourceMaterialChunk[] = [];
+
+  const baseChapterId = generateUUID();
+  const primaryChapter: NewSourceMaterialChapter = {
+    id: baseChapterId,
+    title: derivedHeadings[0] ?? "Imported Material",
+    sequence: 0,
+    headings: derivedHeadings,
+  };
+
+  chapters.push(primaryChapter);
+
+  const chunkTexts = splitIntoChunks(normalized, chunkSize);
+  chunkTexts.forEach((chunkText, index) => {
+    chunks.push({
+      id: generateUUID(),
+      chapterId: baseChapterId,
+      sequence: index,
+      text: chunkText,
+    });
+  });
+
+  return { chapters, chunks };
+}
+
+export function normalizeExtraction({
+  bytes,
+  content,
+  chunkSize,
+}: {
+  bytes: ArrayBuffer;
+  content: ExtractedContent;
+  chunkSize: number;
+}): NormalizedExtraction {
+  const { chapters, chunks } = buildChaptersAndChunks({
+    text: content.text,
+    headings: content.headings,
+    chunkSize,
+  });
+
+  const normalizedText = normalizeTextContent(content.text);
+
+  return {
+    chapters,
+    chunks,
+    metrics: {
+      bytesProcessed: bytes.byteLength,
+      normalizedCharacters: normalizedText.length,
+      chapterCount: chapters.length,
+      chunkCount: chunks.length,
+      metadata: content.metadata,
+    },
+  };
+}

--- a/lib/ingestion/extractors/docx.ts
+++ b/lib/ingestion/extractors/docx.ts
@@ -1,0 +1,21 @@
+import { Buffer } from "node:buffer";
+
+import type { ExtractionStrategy } from "../types";
+import { deriveHeadings } from "../text";
+
+export const docxExtractor: ExtractionStrategy = {
+  mimeTypes: ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
+  async extract({ bytes }) {
+    const mammoth = await import("mammoth");
+    const result = await mammoth.extractRawText({ buffer: Buffer.from(bytes) });
+    const text = result.value ?? "";
+
+    return {
+      text,
+      headings: deriveHeadings(text),
+      metadata: {
+        warnings: result.messages,
+      },
+    };
+  },
+};

--- a/lib/ingestion/extractors/epub.ts
+++ b/lib/ingestion/extractors/epub.ts
@@ -1,0 +1,37 @@
+import { Buffer } from "node:buffer";
+
+import JSZip from "jszip";
+
+import type { ExtractionStrategy } from "../types";
+import { deriveHeadings, stripHtml } from "../text";
+
+export const epubExtractor: ExtractionStrategy = {
+  mimeTypes: ["application/epub+zip"],
+  async extract({ bytes }) {
+    const zip = await new JSZip().loadAsync(Buffer.from(bytes));
+    const htmlFiles = Object.keys(zip.files).filter(
+      (fileName) =>
+        fileName.toLowerCase().endsWith(".xhtml") ||
+        fileName.toLowerCase().endsWith(".html")
+    );
+
+    const segments: string[] = [];
+
+    for (const fileName of htmlFiles) {
+      const file = zip.files[fileName];
+      if (!file) continue;
+      const content = await file.async("string");
+      segments.push(stripHtml(content));
+    }
+
+    const text = segments.join("\n\n");
+
+    return {
+      text,
+      headings: deriveHeadings(text),
+      metadata: {
+        manifestEntries: htmlFiles.length,
+      },
+    };
+  },
+};

--- a/lib/ingestion/extractors/index.ts
+++ b/lib/ingestion/extractors/index.ts
@@ -1,0 +1,46 @@
+import { supportedIngestionMimeTypes } from "../mime-types";
+import type { ExtractionStrategy, SourceMaterialExtractor } from "../types";
+import { docxExtractor } from "./docx";
+import { epubExtractor } from "./epub";
+import { pdfExtractor } from "./pdf";
+import { plainTextExtractor } from "./plain-text";
+
+export class ExtractorRegistry {
+  private readonly strategies: Map<string, SourceMaterialExtractor>;
+
+  constructor(strategies?: Map<string, SourceMaterialExtractor>) {
+    this.strategies = strategies ?? new Map();
+  }
+
+  register(strategy: ExtractionStrategy): void {
+    strategy.mimeTypes.forEach((mimeType) => {
+      this.strategies.set(mimeType.toLowerCase(), strategy);
+    });
+  }
+
+  resolve(mimeType: string): SourceMaterialExtractor {
+    const normalized = mimeType.toLowerCase();
+
+    if (!supportedIngestionMimeTypes.has(normalized)) {
+      throw new Error(`Unsupported MIME type: ${normalized}`);
+    }
+
+    const strategy = this.strategies.get(normalized);
+    if (!strategy) {
+      throw new Error(`No extractor registered for MIME type: ${normalized}`);
+    }
+
+    return strategy;
+  }
+}
+
+export function createDefaultExtractorRegistry(): ExtractorRegistry {
+  const registry = new ExtractorRegistry();
+  [pdfExtractor, epubExtractor, docxExtractor, plainTextExtractor].forEach(
+    (strategy) => registry.register(strategy)
+  );
+
+  return registry;
+}
+
+export { pdfExtractor, epubExtractor, docxExtractor, plainTextExtractor };

--- a/lib/ingestion/extractors/pdf.ts
+++ b/lib/ingestion/extractors/pdf.ts
@@ -1,0 +1,23 @@
+import { Buffer } from "node:buffer";
+
+import type { ExtractionStrategy } from "../types";
+import { deriveHeadings } from "../text";
+
+export const pdfExtractor: ExtractionStrategy = {
+  mimeTypes: ["application/pdf"],
+  async extract({ bytes }) {
+    const { default: pdfParse } = await import("pdf-parse");
+    const parsed = await pdfParse(Buffer.from(bytes));
+    const text = parsed.text ?? "";
+
+    return {
+      text,
+      headings: deriveHeadings(text),
+      metadata: {
+        info: parsed.info ?? null,
+        metadata: parsed.metadata ?? null,
+        numberOfPages: parsed.numpages ?? null,
+      },
+    };
+  },
+};

--- a/lib/ingestion/extractors/plain-text.ts
+++ b/lib/ingestion/extractors/plain-text.ts
@@ -1,0 +1,13 @@
+import type { ExtractionStrategy } from "../types";
+import { deriveHeadings } from "../text";
+
+export const plainTextExtractor: ExtractionStrategy = {
+  mimeTypes: ["text/plain"],
+  async extract({ bytes }) {
+    const text = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+    return {
+      text,
+      headings: deriveHeadings(text),
+    };
+  },
+};

--- a/lib/ingestion/mime-types.ts
+++ b/lib/ingestion/mime-types.ts
@@ -1,0 +1,10 @@
+export const supportedIngestionMimeTypes = new Set<string>([
+  "application/pdf",
+  "application/epub+zip",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "text/plain",
+]);
+
+export function isSupportedIngestionMimeType(mimeType: string): boolean {
+  return supportedIngestionMimeTypes.has(mimeType.toLowerCase());
+}

--- a/lib/ingestion/repository-db.ts
+++ b/lib/ingestion/repository-db.ts
@@ -1,0 +1,82 @@
+import {
+  getSourceMaterialsReadyForProcessing,
+  saveSourceMaterialExtraction,
+  updateSourceMaterial,
+  updateSourceMaterialProcessing,
+  upsertSourceMaterialProcessing,
+} from "@/lib/db/queries";
+import type {
+  NewSourceMaterialChapter,
+  NewSourceMaterialChunk,
+  SourceMaterial,
+  SourceMaterialProcessing,
+} from "@/lib/db/schema";
+
+import type {
+  IngestionRepository,
+  SourceMaterialWithProcessing,
+} from "./repository";
+
+export class DatabaseIngestionRepository implements IngestionRepository {
+  async getReadyMaterials(
+    limit: number
+  ): Promise<SourceMaterialWithProcessing[]> {
+    return getSourceMaterialsReadyForProcessing({ limit });
+  }
+
+  async markStatus(
+    id: string,
+    status: SourceMaterial["status"]
+  ): Promise<void> {
+    await updateSourceMaterial({ id, status });
+  }
+
+  async saveProcessing(params: {
+    sourceMaterialId: string;
+    projectId: string;
+    userId: string;
+    status?: SourceMaterialProcessing["status"];
+    attempts?: number;
+    nextAttemptAt?: Date;
+    lastError?: string | null;
+    startedAt?: Date | null;
+    completedAt?: Date | null;
+    bytesProcessed?: number;
+    chapters?: number;
+    chunks?: number;
+    normalizedCharacters?: number;
+    durationMs?: number;
+    metadata?: Record<string, unknown> | null;
+  }): Promise<SourceMaterialProcessing> {
+    return upsertSourceMaterialProcessing(params);
+  }
+
+  async updateProcessing(params: {
+    sourceMaterialId: string;
+    nextAttemptAt?: Date;
+    attempts?: number;
+    lastError?: string | null;
+    status?: SourceMaterialProcessing["status"];
+    metadata?: Record<string, unknown> | null;
+  }): Promise<SourceMaterialProcessing | null> {
+    return updateSourceMaterialProcessing(params);
+  }
+
+  async persistExtraction({
+    material,
+    chapters,
+    chunks,
+  }: {
+    material: SourceMaterial;
+    chapters: NewSourceMaterialChapter[];
+    chunks: NewSourceMaterialChunk[];
+  }): Promise<void> {
+    await saveSourceMaterialExtraction({
+      chapters,
+      chunks,
+      materialId: material.id,
+      projectId: material.projectId,
+      userId: material.userId,
+    });
+  }
+}

--- a/lib/ingestion/repository.ts
+++ b/lib/ingestion/repository.ts
@@ -1,0 +1,46 @@
+import type {
+  NewSourceMaterialChapter,
+  NewSourceMaterialChunk,
+  SourceMaterial,
+  SourceMaterialProcessing,
+} from "@/lib/db/schema";
+
+export type SourceMaterialWithProcessing = {
+  material: SourceMaterial;
+  processing: SourceMaterialProcessing | null;
+};
+
+export type IngestionRepository = {
+  getReadyMaterials: (limit: number) => Promise<SourceMaterialWithProcessing[]>;
+  markStatus: (id: string, status: SourceMaterial["status"]) => Promise<void>;
+  saveProcessing: (params: {
+    sourceMaterialId: string;
+    projectId: string;
+    userId: string;
+    status?: SourceMaterialProcessing["status"];
+    attempts?: number;
+    nextAttemptAt?: Date;
+    lastError?: string | null;
+    startedAt?: Date | null;
+    completedAt?: Date | null;
+    bytesProcessed?: number;
+    chapters?: number;
+    chunks?: number;
+    normalizedCharacters?: number;
+    durationMs?: number;
+    metadata?: Record<string, unknown> | null;
+  }) => Promise<SourceMaterialProcessing>;
+  updateProcessing: (params: {
+    sourceMaterialId: string;
+    nextAttemptAt?: Date;
+    attempts?: number;
+    lastError?: string | null;
+    status?: SourceMaterialProcessing["status"];
+    metadata?: Record<string, unknown> | null;
+  }) => Promise<SourceMaterialProcessing | null>;
+  persistExtraction: (args: {
+    material: SourceMaterial;
+    chapters: NewSourceMaterialChapter[];
+    chunks: NewSourceMaterialChunk[];
+  }) => Promise<void>;
+};

--- a/lib/ingestion/text.ts
+++ b/lib/ingestion/text.ts
@@ -1,0 +1,34 @@
+export function normalizeTextContent(text: string): string {
+  return text
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/\u0000/g, "")
+    .replace(/[\t ]+\n/g, "\n")
+    .replace(/\s+$/g, "")
+    .trim();
+}
+
+export function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function deriveHeadings(text: string): string[] {
+  const headings = new Set<string>();
+  const lines = normalizeTextContent(text).split("\n");
+  const headingRegex = /^(?:#+\s+|chapter\s+\d+[:\-\s]*)(.+)/i;
+
+  for (const line of lines) {
+    const match = line.match(headingRegex);
+    if (match?.[1]) {
+      const heading = match[1].trim();
+      if (heading) {
+        headings.add(heading);
+      }
+    }
+  }
+
+  return [...headings];
+}

--- a/lib/ingestion/types.ts
+++ b/lib/ingestion/types.ts
@@ -1,0 +1,40 @@
+import type {
+  NewSourceMaterialChapter,
+  NewSourceMaterialChunk,
+  SourceMaterial,
+} from "@/lib/db/schema";
+
+export type BlobFetcher = (url: string) => Promise<Response>;
+
+export type ExtractedContent = {
+  text: string;
+  headings: string[];
+  metadata?: Record<string, unknown>;
+};
+
+export type ExtractionMetrics = {
+  bytesProcessed: number;
+  normalizedCharacters: number;
+  chapterCount: number;
+  chunkCount: number;
+  metadata?: Record<string, unknown>;
+};
+
+export type NormalizedExtraction = {
+  chapters: NewSourceMaterialChapter[];
+  chunks: NewSourceMaterialChunk[];
+  metrics: ExtractionMetrics;
+};
+
+export type ExtractionInput = {
+  material: SourceMaterial;
+  bytes: ArrayBuffer;
+};
+
+export type SourceMaterialExtractor = {
+  extract: (input: ExtractionInput) => Promise<ExtractedContent>;
+};
+
+export type ExtractionStrategy = SourceMaterialExtractor & {
+  mimeTypes: string[];
+};

--- a/lib/ingestion/worker.ts
+++ b/lib/ingestion/worker.ts
@@ -1,369 +1,50 @@
-import { Buffer } from "node:buffer";
+import type { SourceMaterial } from "@/lib/db/schema";
 
-import JSZip from "jszip";
+import { calculateBackoff, DEFAULT_BASE_BACKOFF_MS, DEFAULT_MAX_ATTEMPTS } from "./backoff";
+import { DEFAULT_CHUNK_SIZE, normalizeExtraction } from "./chunking";
+import { createDefaultExtractorRegistry, ExtractorRegistry } from "./extractors";
+import type { IngestionRepository, SourceMaterialWithProcessing } from "./repository";
+import type { BlobFetcher, SourceMaterialExtractor } from "./types";
+import { normalizeTextContent } from "./text";
 
-import {
-  getSourceMaterialsReadyForProcessing,
-  type SourceMaterialWithProcessing,
-  saveSourceMaterialExtraction,
-  type UpsertSourceMaterialProcessingArgs,
-  updateSourceMaterial,
-  updateSourceMaterialProcessing,
-  upsertSourceMaterialProcessing,
-} from "@/lib/db/queries";
-import type {
-  NewSourceMaterialChapter,
-  NewSourceMaterialChunk,
-  SourceMaterial,
-  SourceMaterialProcessing,
-} from "@/lib/db/schema";
-import { supportedSourceMaterialMimeTypes } from "@/lib/source-materials";
-import { generateUUID } from "@/lib/utils";
-
-type BlobFetcher = (url: string) => Promise<Response>;
-
-type ExtractedContent = {
-  text: string;
-  headings: string[];
-  metadata?: Record<string, unknown>;
-};
-
-type ExtractionResult = {
-  chapters: NewSourceMaterialChapter[];
-  chunks: NewSourceMaterialChunk[];
-  metrics: {
-    bytesProcessed: number;
-    normalizedCharacters: number;
-    chapterCount: number;
-    chunkCount: number;
-    metadata?: Record<string, unknown>;
-  };
-};
-
-type SourceMaterialExtractor = {
-  extract: (input: {
-    material: SourceMaterial;
-    bytes: ArrayBuffer;
-  }) => Promise<ExtractedContent>;
-};
-
-type IngestionRepository = {
-  getReadyMaterials: (limit: number) => Promise<SourceMaterialWithProcessing[]>;
-  markStatus: (id: string, status: SourceMaterial["status"]) => Promise<void>;
-  saveProcessing: (
-    params: UpsertSourceMaterialProcessingArgs
-  ) => Promise<SourceMaterialProcessing>;
-  updateProcessing: (
-    params: Parameters<typeof updateSourceMaterialProcessing>[0]
-  ) => Promise<SourceMaterialProcessing | null>;
-  persistExtraction: (args: {
-    material: SourceMaterial;
-    chapters: NewSourceMaterialChapter[];
-    chunks: NewSourceMaterialChunk[];
-  }) => Promise<void>;
-};
-
-const DEFAULT_CHUNK_SIZE = 1200;
 const DEFAULT_BATCH_SIZE = 5;
-const BASE_BACKOFF_MS = 1000;
-const DEFAULT_MAX_ATTEMPTS = 3;
-
-function cleanText(text: string): string {
-  return text
-    .replace(/\r\n/g, "\n")
-    .replace(/\r/g, "\n")
-    .replace(/\u0000/g, "")
-    .replace(/[\t ]+\n/g, "\n")
-    .trim();
-}
-
-function stripHtml(html: string): string {
-  return html
-    .replace(/<[^>]+>/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function splitIntoChunks(text: string, chunkSize: number): string[] {
-  if (!text) return [];
-
-  const normalized = cleanText(text);
-  const parts: string[] = [];
-  let cursor = 0;
-
-  while (cursor < normalized.length) {
-    const slice = normalized.slice(cursor, cursor + chunkSize);
-    const lastSpace = slice.lastIndexOf(" ");
-    const end = lastSpace > 0 ? cursor + lastSpace : cursor + slice.length;
-    parts.push(normalized.slice(cursor, end).trim());
-    cursor = end;
-  }
-
-  return parts.filter(Boolean);
-}
-
-function deriveHeadings(text: string): string[] {
-  const headings = new Set<string>();
-  const lines = cleanText(text).split("\n");
-  const headingRegex = /^(?:#+\s+|chapter\s+\d+[:\-\s]*)(.+)/i;
-
-  for (const line of lines) {
-    const match = line.match(headingRegex);
-    if (match?.[1]) {
-      const heading = match[1].trim();
-      if (heading) {
-        headings.add(heading);
-      }
-    }
-  }
-
-  return [...headings];
-}
-
-async function extractFromPdf(bytes: ArrayBuffer): Promise<ExtractedContent> {
-  const { default: pdfParse } = await import("pdf-parse");
-  const parsed = await pdfParse(Buffer.from(bytes));
-  const text = parsed.text ?? "";
-
-  return {
-    text,
-    headings: deriveHeadings(text),
-    metadata: {
-      info: parsed.info ?? null,
-      metadata: parsed.metadata ?? null,
-      numberOfPages: parsed.numpages ?? null,
-    },
-  };
-}
-
-async function extractFromDocx(bytes: ArrayBuffer): Promise<ExtractedContent> {
-  const mammoth = await import("mammoth");
-  const result = await mammoth.extractRawText({ buffer: Buffer.from(bytes) });
-  const text = result.value ?? "";
-
-  return {
-    text,
-    headings: deriveHeadings(text),
-    metadata: {
-      warnings: result.messages,
-    },
-  };
-}
-
-async function extractFromEpub(bytes: ArrayBuffer): Promise<ExtractedContent> {
-  const zip = await new JSZip().loadAsync(Buffer.from(bytes));
-  const htmlFiles = Object.keys(zip.files).filter(
-    (fileName) =>
-      fileName.toLowerCase().endsWith(".xhtml") ||
-      fileName.toLowerCase().endsWith(".html")
-  );
-
-  const segments: string[] = [];
-
-  for (const fileName of htmlFiles) {
-    const file = zip.files[fileName];
-    if (!file) continue;
-    const content = await file.async("string");
-    segments.push(stripHtml(content));
-  }
-
-  const text = segments.join("\n\n");
-
-  return {
-    text,
-    headings: deriveHeadings(text),
-    metadata: {
-      manifestEntries: htmlFiles.length,
-    },
-  };
-}
-
-function extractFromPlainText(bytes: ArrayBuffer): ExtractedContent {
-  const text = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
-  return {
-    text,
-    headings: deriveHeadings(text),
-  };
-}
-
-class DefaultSourceMaterialExtractor implements SourceMaterialExtractor {
-  async extract({
-    bytes,
-    material,
-  }: {
-    bytes: ArrayBuffer;
-    material: SourceMaterial;
-  }): Promise<ExtractedContent> {
-    const mimeType = material.mimeType.toLowerCase();
-
-    if (!supportedSourceMaterialMimeTypes.has(mimeType)) {
-      throw new Error(`Unsupported MIME type: ${mimeType}`);
-    }
-
-    if (mimeType === "application/pdf") {
-      return extractFromPdf(bytes);
-    }
-
-    if (mimeType === "application/epub+zip") {
-      return extractFromEpub(bytes);
-    }
-
-    if (
-      mimeType ===
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-    ) {
-      return extractFromDocx(bytes);
-    }
-
-    return extractFromPlainText(bytes);
-  }
-}
-
-class DatabaseIngestionRepository implements IngestionRepository {
-  async getReadyMaterials(
-    limit: number
-  ): Promise<SourceMaterialWithProcessing[]> {
-    return getSourceMaterialsReadyForProcessing({ limit });
-  }
-
-  async markStatus(
-    id: string,
-    status: SourceMaterial["status"]
-  ): Promise<void> {
-    await updateSourceMaterial({ id, status });
-  }
-
-  async saveProcessing(
-    params: UpsertSourceMaterialProcessingArgs
-  ): Promise<SourceMaterialProcessing> {
-    return upsertSourceMaterialProcessing(params);
-  }
-
-  async updateProcessing(
-    params: Parameters<typeof updateSourceMaterialProcessing>[0]
-  ): Promise<SourceMaterialProcessing | null> {
-    return updateSourceMaterialProcessing(params);
-  }
-
-  async persistExtraction({
-    material,
-    chapters,
-    chunks,
-  }: {
-    material: SourceMaterial;
-    chapters: NewSourceMaterialChapter[];
-    chunks: NewSourceMaterialChunk[];
-  }): Promise<void> {
-    await saveSourceMaterialExtraction({
-      chapters,
-      chunks,
-      materialId: material.id,
-      projectId: material.projectId,
-      userId: material.userId,
-    });
-  }
-}
-
-function buildChaptersAndChunks({
-  text,
-  headings,
-  chunkSize,
-}: {
-  text: string;
-  headings: string[];
-  chunkSize: number;
-}): { chapters: NewSourceMaterialChapter[]; chunks: NewSourceMaterialChunk[] } {
-  const normalized = cleanText(text);
-
-  if (!normalized) {
-    return { chapters: [], chunks: [] };
-  }
-
-  const derivedHeadings =
-    headings.length > 0 ? headings : deriveHeadings(normalized);
-
-  const chapters: NewSourceMaterialChapter[] = [];
-  const chunks: NewSourceMaterialChunk[] = [];
-
-  const baseChapterId = generateUUID();
-  const primaryChapter: NewSourceMaterialChapter = {
-    id: baseChapterId,
-    title: derivedHeadings[0] ?? "Imported Material",
-    sequence: 0,
-    headings: derivedHeadings,
-  };
-
-  chapters.push(primaryChapter);
-
-  const chunkTexts = splitIntoChunks(normalized, chunkSize);
-  chunkTexts.forEach((chunkText, index) => {
-    chunks.push({
-      id: generateUUID(),
-      chapterId: baseChapterId,
-      sequence: index,
-      text: chunkText,
-    });
-  });
-
-  return { chapters, chunks };
-}
-
-function normalizeExtraction({
-  bytes,
-  content,
-  chunkSize,
-}: {
-  bytes: ArrayBuffer;
-  content: ExtractedContent;
-  chunkSize: number;
-}): ExtractionResult {
-  const { chapters, chunks } = buildChaptersAndChunks({
-    text: content.text,
-    headings: content.headings,
-    chunkSize,
-  });
-
-  const normalizedText = cleanText(content.text);
-
-  return {
-    chapters,
-    chunks,
-    metrics: {
-      bytesProcessed: bytes.byteLength,
-      normalizedCharacters: normalizedText.length,
-      chapterCount: chapters.length,
-      chunkCount: chunks.length,
-      metadata: content.metadata,
-    },
-  };
-}
 
 export class SourceMaterialWorker {
-  private readonly repository: IngestionRepository;
+  private repository: IngestionRepository | null;
+
   private readonly fetcher: BlobFetcher;
-  private readonly extractor: SourceMaterialExtractor;
+
+  private readonly extractorRegistry: ExtractorRegistry;
+
   private readonly chunkSize: number;
+
   private readonly batchSize: number;
+
+  private readonly baseDelayMs: number;
+
   private readonly maxAttempts: number;
 
   constructor(options?: {
     repository?: IngestionRepository;
     fetcher?: BlobFetcher;
-    extractor?: SourceMaterialExtractor;
+    extractorRegistry?: ExtractorRegistry;
     chunkSize?: number;
     batchSize?: number;
-    maxAttempts?: number;
+    backoff?: { baseDelayMs?: number; maxAttempts?: number };
   }) {
-    this.repository = options?.repository ?? new DatabaseIngestionRepository();
+    this.repository = options?.repository ?? null;
     this.fetcher = options?.fetcher ?? fetch;
-    this.extractor = options?.extractor ?? new DefaultSourceMaterialExtractor();
+    this.extractorRegistry =
+      options?.extractorRegistry ?? createDefaultExtractorRegistry();
     this.chunkSize = options?.chunkSize ?? DEFAULT_CHUNK_SIZE;
     this.batchSize = options?.batchSize ?? DEFAULT_BATCH_SIZE;
-    this.maxAttempts = options?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    this.baseDelayMs = options?.backoff?.baseDelayMs ?? DEFAULT_BASE_BACKOFF_MS;
+    this.maxAttempts = options?.backoff?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
   }
 
   async runBatch(): Promise<void> {
-    const materials = await this.repository.getReadyMaterials(this.batchSize);
+    const repository = await this.getRepository();
+    const materials = await repository.getReadyMaterials(this.batchSize);
 
     for (const item of materials) {
       // eslint-disable-next-line no-await-in-loop
@@ -371,10 +52,21 @@ export class SourceMaterialWorker {
     }
   }
 
+  private async getRepository(): Promise<IngestionRepository> {
+    if (this.repository) {
+      return this.repository;
+    }
+
+    const { DatabaseIngestionRepository } = await import("./repository-db");
+    this.repository = new DatabaseIngestionRepository();
+    return this.repository;
+  }
+
   private async processMaterial({
     material,
     processing,
   }: SourceMaterialWithProcessing): Promise<void> {
+    const repository = await this.getRepository();
     const attempts = processing?.attempts ?? 0;
     const nextAttemptAt = processing?.nextAttemptAt ?? new Date();
 
@@ -384,7 +76,7 @@ export class SourceMaterialWorker {
 
     const startedAt = new Date();
 
-    await this.repository.saveProcessing({
+    await repository.saveProcessing({
       attempts,
       nextAttemptAt: startedAt,
       projectId: material.projectId,
@@ -394,7 +86,7 @@ export class SourceMaterialWorker {
       userId: material.userId,
     });
 
-    await this.repository.markStatus(material.id, "processing");
+    await repository.markStatus(material.id, "processing");
 
     if (!material.blobUrl) {
       await this.recordFailure({
@@ -413,14 +105,17 @@ export class SourceMaterialWorker {
       }
 
       const bytes = await response.arrayBuffer();
-      const content = await this.extractor.extract({ material, bytes });
+      const content = await this.extract(material.mimeType).extract({
+        material,
+        bytes,
+      });
       const normalized = normalizeExtraction({
         bytes,
         content,
         chunkSize: this.chunkSize,
       });
 
-      await this.repository.persistExtraction({
+      await repository.persistExtraction({
         material,
         chapters: normalized.chapters,
         chunks: normalized.chunks,
@@ -429,7 +124,7 @@ export class SourceMaterialWorker {
       const completedAt = new Date();
       const durationMs = completedAt.getTime() - startedAt.getTime();
 
-      await this.repository.saveProcessing({
+      await repository.saveProcessing({
         attempts: attempts + 1,
         bytesProcessed: normalized.metrics.bytesProcessed,
         chapters: normalized.metrics.chapterCount,
@@ -447,10 +142,14 @@ export class SourceMaterialWorker {
         userId: material.userId,
       });
 
-      await this.repository.markStatus(material.id, "processed");
+      await repository.markStatus(material.id, "processed");
     } catch (error) {
       await this.recordFailure({ material, attempts, error: error as Error });
     }
+  }
+
+  private extract(mimeType: string): SourceMaterialExtractor {
+    return this.extractorRegistry.resolve(mimeType);
   }
 
   private async recordFailure({
@@ -462,13 +161,12 @@ export class SourceMaterialWorker {
     attempts: number;
     error: Error;
   }): Promise<void> {
-    const nextAttempts = attempts + 1;
-    const shouldFail = nextAttempts >= this.maxAttempts;
-    const delayMs = BASE_BACKOFF_MS * 2 ** attempts;
-    const nextAttemptAt = shouldFail
-      ? new Date()
-      : new Date(Date.now() + delayMs);
-    const status = shouldFail ? "failed" : "uploaded";
+    const repository = await this.getRepository();
+    const { nextAttempts, nextAttemptAt, status } = calculateBackoff({
+      attempts,
+      baseDelayMs: this.baseDelayMs,
+      maxAttempts: this.maxAttempts,
+    });
 
     console.error(
       "Failed to process source material",
@@ -481,7 +179,7 @@ export class SourceMaterialWorker {
       error
     );
 
-    await this.repository.saveProcessing({
+    await repository.saveProcessing({
       attempts: nextAttempts,
       lastError: error.message,
       nextAttemptAt,
@@ -491,20 +189,21 @@ export class SourceMaterialWorker {
       userId: material.userId,
     });
 
-    await this.repository.markStatus(material.id, status);
+    await repository.markStatus(material.id, status);
   }
 }
 
 export function createWorker(options?: {
   repository?: IngestionRepository;
   fetcher?: BlobFetcher;
-  extractor?: SourceMaterialExtractor;
+  extractorRegistry?: ExtractorRegistry;
   chunkSize?: number;
   batchSize?: number;
-  maxAttempts?: number;
+  backoff?: { baseDelayMs?: number; maxAttempts?: number };
 }): SourceMaterialWorker {
   return new SourceMaterialWorker(options);
 }
 
-export { cleanText as normalizeTextContent };
-export type { IngestionRepository, SourceMaterialExtractor, ExtractedContent };
+export { normalizeTextContent };
+export type { IngestionRepository, SourceMaterialWithProcessing };
+export type { SourceMaterialExtractor, ExtractedContent } from "./types";

--- a/lib/source-materials.ts
+++ b/lib/source-materials.ts
@@ -3,105 +3,104 @@ import { randomUUID } from "node:crypto";
 import type { UserType } from "@/app/(auth)/auth";
 import { createSourceMaterial, updateSourceMaterial } from "@/lib/db/queries";
 import type { SourceMaterial } from "@/lib/db/schema";
+import {
+  isSupportedIngestionMimeType,
+  supportedIngestionMimeTypes,
+} from "@/lib/ingestion/mime-types";
 
-export const supportedSourceMaterialMimeTypes = new Set<string>([
-	"application/pdf",
-	"application/epub+zip",
-	"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-	"text/plain",
-]);
+export const supportedSourceMaterialMimeTypes = supportedIngestionMimeTypes;
 
 export const sourceMaterialSizeLimits: Record<UserType, number> = {
-	regular: 20 * 1024 * 1024,
+  regular: 20 * 1024 * 1024,
 };
 
 export type SerializedSourceMaterial = Omit<
-	SourceMaterial,
-	"createdAt" | "updatedAt"
+  SourceMaterial,
+  "createdAt" | "updatedAt"
 > & {
-	createdAt: string;
-	updatedAt: string;
+  createdAt: string;
+  updatedAt: string;
 };
 
 export function isSupportedSourceMaterialType(mimeType: string): boolean {
-	return supportedSourceMaterialMimeTypes.has(mimeType.toLowerCase());
+  return isSupportedIngestionMimeType(mimeType);
 }
 
 export function sanitizeSourceMaterialName(filename: string): string {
-	const trimmed = filename.trim();
-	const safeName = trimmed.replace(/[^a-zA-Z0-9._-]+/g, "_");
-	return safeName.length > 0 ? safeName : `upload-${randomUUID()}`;
+  const trimmed = filename.trim();
+  const safeName = trimmed.replace(/[^a-zA-Z0-9._-]+/g, "_");
+  return safeName.length > 0 ? safeName : `upload-${randomUUID()}`;
 }
 
 export function getSourceMaterialUploadKey(
-	projectId: string,
-	filename: string,
+  projectId: string,
+  filename: string
 ): string {
-	const timestamp = Date.now();
-	const safeName = sanitizeSourceMaterialName(filename);
-	return `projects/${projectId}/${timestamp}-${safeName}`;
+  const timestamp = Date.now();
+  const safeName = sanitizeSourceMaterialName(filename);
+  return `projects/${projectId}/${timestamp}-${safeName}`;
 }
 
 export function serializeSourceMaterial(
-	material: SourceMaterial,
+  material: SourceMaterial
 ): SerializedSourceMaterial {
-	return {
-		...material,
-		createdAt: material.createdAt.toISOString(),
-		updatedAt: material.updatedAt.toISOString(),
-	};
+  return {
+    ...material,
+    createdAt: material.createdAt.toISOString(),
+    updatedAt: material.updatedAt.toISOString(),
+  };
 }
 
 export async function createPendingSourceMaterial({
-	filename,
-	mimeType,
-	projectId,
-	size,
-	userId,
+  filename,
+  mimeType,
+  projectId,
+  size,
+  userId,
 }: {
-	filename: string;
-	mimeType: string;
-	projectId: string;
-	size: number;
-	userId: string;
+  filename: string;
+  mimeType: string;
+  projectId: string;
+  size: number;
+  userId: string;
 }): Promise<SourceMaterial> {
-	return createSourceMaterial({
-		filename,
-		mimeType,
-		projectId,
-		size,
-		status: "pending",
-		userId,
-	});
+  return createSourceMaterial({
+    filename,
+    mimeType,
+    projectId,
+    size,
+    status: "pending",
+    userId,
+  });
 }
 
 export async function markSourceMaterialAsUploaded({
-	blobUrl,
-	id,
+  blobUrl,
+  id,
 }: {
-	blobUrl: string;
-	id: string;
+  blobUrl: string;
+  id: string;
 }): Promise<SourceMaterial | null> {
-	return updateSourceMaterial({
-		blobUrl,
-		id,
-		status: "uploaded",
-	});
+  return updateSourceMaterial({
+    blobUrl,
+    id,
+    status: "uploaded",
+  });
 }
 
 export async function markSourceMaterialAsFailed({
-	id,
+  id,
 }: {
-	id: string;
+  id: string;
 }): Promise<SourceMaterial | null> {
-	return updateSourceMaterial({
-		blobUrl: null,
-		id,
-		status: "failed",
-	});
+  return updateSourceMaterial({
+    blobUrl: null,
+    id,
+    status: "failed",
+  });
 }
 
 export function formatBytes(bytes: number): string {
-	const megabytes = bytes / (1024 * 1024);
-	return `${megabytes.toFixed(1)}MB`;
+  const megabytes = bytes / (1024 * 1024);
+  return `${megabytes.toFixed(1)}MB`;
 }

--- a/tests/unit/ingestion/chunking.test.ts
+++ b/tests/unit/ingestion/chunking.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { buildChaptersAndChunks, splitIntoChunks } from "@/lib/ingestion/chunking";
+import { deriveHeadings, normalizeTextContent } from "@/lib/ingestion/text";
+
+const sampleText = `# Chapter 1
+This is a paragraph that should be split into smaller chunks for processing.`;
+
+describe("chunking utilities", () => {
+  it("splits text into bounded chunks", () => {
+    const chunks = splitIntoChunks("hello world from the worker", 10);
+    expect(chunks).toHaveLength(4);
+    expect(chunks.every((chunk) => chunk.length <= 10)).toBe(true);
+    expect(chunks[0]).toBe("hello");
+  });
+
+  it("produces chapters and chunks with derived headings", () => {
+    const { chapters, chunks } = buildChaptersAndChunks({
+      text: sampleText,
+      headings: [],
+      chunkSize: 30,
+    });
+
+    expect(chapters).toHaveLength(1);
+    expect(chapters[0]?.title).toBe("Chapter 1");
+    expect(chapters[0]?.headings).toContain("Chapter 1");
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+});
+
+describe("text normalization", () => {
+  it("cleans control characters and trailing whitespace", () => {
+    const dirty = "Line one\r\nLine two\u0000\n\n";
+    expect(normalizeTextContent(dirty)).toBe("Line one\nLine two");
+  });
+
+  it("extracts headings from markdown and numbered chapters", () => {
+    const headings = deriveHeadings("## Intro\nChapter 2: Basics\nBody");
+    expect(headings).toEqual(["Intro", "Basics"]);
+  });
+});

--- a/tests/unit/ingestion/extractors.test.ts
+++ b/tests/unit/ingestion/extractors.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ExtractorRegistry,
+  createDefaultExtractorRegistry,
+} from "@/lib/ingestion/extractors";
+import type { ExtractionStrategy } from "@/lib/ingestion/types";
+
+const fakeStrategy: ExtractionStrategy = {
+  mimeTypes: ["text/plain"],
+  async extract() {
+    return { text: "content", headings: [] };
+  },
+};
+
+describe("ExtractorRegistry", () => {
+  it("returns a registered strategy by mime type", async () => {
+    const registry = new ExtractorRegistry();
+    registry.register(fakeStrategy);
+
+    const extractor = registry.resolve("text/plain");
+    const result = await extractor.extract({
+      bytes: new ArrayBuffer(0),
+      material: {
+        id: "material-1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        filename: "file.txt",
+        mimeType: "text/plain",
+        size: 1,
+        status: "uploaded",
+        blobUrl: "http://example.com/blob",
+        projectId: "project-1",
+        userId: "user-1",
+      },
+    });
+
+    expect(result.text).toBe("content");
+  });
+
+  it("throws for unsupported mime types", () => {
+    const registry = createDefaultExtractorRegistry();
+    expect(() => registry.resolve("application/unknown" as any)).toThrow(
+      /Unsupported MIME type/
+    );
+  });
+});

--- a/tests/unit/ingestion/worker.test.ts
+++ b/tests/unit/ingestion/worker.test.ts
@@ -1,18 +1,14 @@
 import { describe, expect, it } from "vitest";
-import type { SourceMaterialWithProcessing } from "@/lib/db/queries";
 import type {
   NewSourceMaterialChapter,
   NewSourceMaterialChunk,
   SourceMaterial,
   SourceMaterialProcessing,
 } from "@/lib/db/schema";
-import {
-  type ExtractedContent,
-  type IngestionRepository,
-  normalizeTextContent,
-  type SourceMaterialExtractor,
-  SourceMaterialWorker,
-} from "@/lib/ingestion/worker";
+import { ExtractorRegistry } from "@/lib/ingestion/extractors";
+import type { IngestionRepository, SourceMaterialWithProcessing } from "@/lib/ingestion/repository";
+import { SourceMaterialWorker, normalizeTextContent } from "@/lib/ingestion/worker";
+import type { ExtractionStrategy } from "@/lib/ingestion/types";
 import { generateUUID } from "@/lib/utils";
 
 class InMemoryRepository implements IngestionRepository {
@@ -144,8 +140,9 @@ const textFetcher = async (body: string) =>
     headers: { "content-type": "text/plain" },
   });
 
-const extractor: SourceMaterialExtractor = {
-  extract: async ({ bytes }): Promise<ExtractedContent> => {
+const extractorStrategy: ExtractionStrategy = {
+  mimeTypes: ["text/plain"],
+  extract: async ({ bytes }) => {
     const text = new TextDecoder().decode(bytes);
     return {
       text,
@@ -153,6 +150,12 @@ const extractor: SourceMaterialExtractor = {
       metadata: { bytes: bytes.byteLength },
     };
   },
+};
+
+const registryWith = (strategy: ExtractionStrategy): ExtractorRegistry => {
+  const registry = new ExtractorRegistry();
+  registry.register(strategy);
+  return registry;
 };
 
 describe("SourceMaterialWorker", () => {
@@ -163,9 +166,8 @@ describe("SourceMaterialWorker", () => {
 
     const worker = new SourceMaterialWorker({
       repository: repo,
-      extractor,
-      fetcher: () =>
-        textFetcher("Intro\nBody content that spans multiple chunks."),
+      extractorRegistry: registryWith(extractorStrategy),
+      fetcher: () => textFetcher("Intro\nBody content that spans multiple chunks."),
       chunkSize: 20,
       batchSize: 1,
     });
@@ -188,30 +190,31 @@ describe("SourceMaterialWorker", () => {
     const material: SourceMaterial = { ...baseMaterial, id: generateUUID() };
 
     const repo = new InMemoryRepository([{ material, processing: null }]);
-    const failingExtractor: SourceMaterialExtractor = {
+    const failingRegistry = registryWith({
+      mimeTypes: ["text/plain"],
       extract: async () => {
         throw new Error("Unable to parse file");
       },
-    };
+    });
 
     const worker = new SourceMaterialWorker({
       repository: repo,
-      extractor: failingExtractor,
+      extractorRegistry: failingRegistry,
       fetcher: () => textFetcher("irrelevant"),
       batchSize: 1,
-      maxAttempts: 2,
+      backoff: { maxAttempts: 2, baseDelayMs: 10 },
     });
 
+    const startedAt = Date.now();
     await worker.runBatch();
 
     const firstProcessing = repo.processing.get(material.id);
 
     expect(firstProcessing?.status).toBe("uploaded");
     expect(firstProcessing?.attempts).toBe(1);
-    expect(firstProcessing?.nextAttemptAt.getTime()).toBeGreaterThan(
-      Date.now()
-    );
+    expect(firstProcessing?.nextAttemptAt.getTime()).toBeGreaterThan(startedAt);
 
+    await new Promise((resolve) => setTimeout(resolve, 25));
     await worker.runBatch();
 
     const finalProcessing = repo.processing.get(material.id);


### PR DESCRIPTION
## Summary
- modularize ingestion logic into extractor strategies, normalization/chunking utilities, and retry/backoff helpers
- introduce MIME-type keyed extractor registry and dependency-injected worker with repository abstraction
- add targeted unit tests for chunking, extractor selection, and worker processing flows

## Testing
- pnpm exec vitest run tests/unit/ingestion


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c268ce2dc83259586833eacf57453)